### PR TITLE
fix: force-delete branch during sync-with-origin cleanup

### DIFF
--- a/apps/cli/src/hooks/useSessionManager.ts
+++ b/apps/cli/src/hooks/useSessionManager.ts
@@ -54,7 +54,7 @@ export function useSessionManager(
     async (sessionName: string, branch: string) => {
       await killSession(sessionName);
       await removeWorktree(branch);
-      await deleteBranch(branch);
+      await deleteBranch(branch, true);
       const updated = await refreshSessions();
       setSelectedIndex((prev) =>
         prev >= updated.length ? Math.max(0, updated.length - 1) : prev

--- a/libs/tmux-manager/src/lib/worktree.ts
+++ b/libs/tmux-manager/src/lib/worktree.ts
@@ -245,9 +245,13 @@ export async function countConflicts(branch: string): Promise<number> {
 }
 
 /** Delete a local git branch. Returns true on success, false on failure. */
-export async function deleteBranch(branch: string): Promise<boolean> {
+export async function deleteBranch(
+  branch: string,
+  force = false
+): Promise<boolean> {
+  const flag = force ? '-D' : '-d';
   try {
-    await exec(`git branch -d "${branch}"`, { encoding: 'utf8' });
+    await exec(`git branch ${flag} "${branch}"`, { encoding: 'utf8' });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- `deleteBranch()` used `git branch -d` (safe delete) which fails on squash-merged branches because git can't verify they're fully merged
- Added a `force` parameter to `deleteBranch()` — when `true`, uses `git branch -D` instead
- `performDelete` (the sync-with-origin cleanup flow) now passes `force: true`, since the upstream VCS API already confirmed the PR is merged

## Test plan

- [x] All 79 tmux-manager tests pass
- [ ] Manual: create a worktree/session, squash-merge the PR on origin, press 'g' — confirm branch is deleted