### PR TITLE
fix: include GitHub review requests in reviews panel

### DIFF
--- a/libs/vcs/github/src/lib/provider.spec.ts
+++ b/libs/vcs/github/src/lib/provider.spec.ts
@@ -116,8 +116,24 @@ describe('latestReviewPerUser', () => {
     expect(bob?.decision).toBe('changes-requested');
   });
 
-  it('returns empty array for no reviews', () => {
+  it('returns empty array for no reviews and no requested reviewers', () => {
     expect(latestReviewPerUser([])).toEqual([]);
+  });
+
+  it('includes requested reviewers with no-response decision', () => {
+    const result = latestReviewPerUser([], [{ login: 'dana' }]);
+    expect(result).toEqual([
+      { displayName: 'dana', identifier: 'dana', decision: 'no-response' },
+    ]);
+  });
+
+  it('actual review overrides requested reviewer pending state', () => {
+    const result = latestReviewPerUser(
+      [{ author: { login: 'dana' }, state: 'APPROVED' }],
+      [{ login: 'dana' }]
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]?.decision).toBe('approved');
   });
 
   it('sets displayName and identifier to login', () => {
@@ -294,6 +310,7 @@ describe('githubProvider', () => {
                 url: 'https://github.com/octocat/hello-world/pull/10',
                 author: { login: 'octocat' },
                 isDraft: false,
+                reviewRequests: { nodes: [] },
                 reviews: {
                   nodes: [{ author: { login: 'bob' }, state: 'APPROVED' }],
                 },
@@ -322,6 +339,7 @@ describe('githubProvider', () => {
                 url: 'https://github.com/octocat/hello-world/pull/11',
                 author: { login: 'alice' },
                 isDraft: true,
+                reviewRequests: { nodes: [] },
                 reviews: { nodes: [] },
                 reviewThreads: { nodes: [] },
                 commits: {
@@ -404,6 +422,7 @@ describe('githubProvider', () => {
                 url: 'https://github.com/o/r/pull/1',
                 author: { login: 'user' },
                 isDraft: false,
+                reviewRequests: { nodes: [] },
                 reviews: { nodes: [] },
                 reviewThreads: { nodes: [] },
                 commits: {
@@ -428,6 +447,7 @@ describe('githubProvider', () => {
                 url: 'https://github.com/o/r/pull/2',
                 author: { login: 'user' },
                 isDraft: false,
+                reviewRequests: { nodes: [] },
                 reviews: { nodes: [] },
                 reviewThreads: { nodes: [] },
                 commits: {

--- a/libs/vcs/github/src/lib/provider.ts
+++ b/libs/vcs/github/src/lib/provider.ts
@@ -75,9 +75,13 @@ export function mapReviewState(state: string): ReviewDecision {
 }
 
 export function latestReviewPerUser(
-  reviews: Array<{ author: { login: string }; state: string }>
+  reviews: Array<{ author: { login: string }; state: string }>,
+  requestedReviewers: Array<{ login: string }> = []
 ): PullRequestReviewer[] {
   const byUser = new Map<string, { login: string; state: string }>();
+  for (const r of requestedReviewers) {
+    byUser.set(r.login, { login: r.login, state: 'PENDING' });
+  }
   for (const r of reviews) {
     byUser.set(r.author.login, { login: r.author.login, state: r.state });
   }
@@ -131,6 +135,13 @@ const SEARCH_PRS_QUERY = `
           url
           author { login }
           isDraft
+          reviewRequests(first: 20) {
+            nodes {
+              requestedReviewer {
+                ... on User { login }
+              }
+            }
+          }
           reviews(last: 100) {
             nodes {
               author { login }
@@ -163,6 +174,9 @@ interface SearchPrNode {
   url: string;
   author: { login: string };
   isDraft: boolean;
+  reviewRequests: {
+    nodes: Array<{ requestedReviewer: { login?: string } }>;
+  };
   reviews: {
     nodes: Array<{ author: { login: string }; state: string }>;
   };
@@ -208,7 +222,13 @@ export function mapRollupState(
 }
 
 function transformSearchNode(node: SearchPrNode): PullRequestInfo {
-  const reviewers = latestReviewPerUser(node.reviews.nodes);
+  const requestedReviewers = node.reviewRequests.nodes
+    .filter((n) => n.requestedReviewer.login)
+    .map((n) => ({ login: n.requestedReviewer.login! }));
+  const reviewers = latestReviewPerUser(
+    node.reviews.nodes,
+    requestedReviewers
+  );
 
   const unresolvedCount = node.reviewThreads.nodes.filter(
     (t) => !t.isResolved


### PR DESCRIPTION
## Summary

- PRs where a user is requested as a reviewer but hasn't submitted a review were fetched by the `involves:` search query but silently dropped during categorization (because reviewers list was built only from submitted reviews)
- Added `reviewRequests` to the GraphQL query and seed the reviewers map with pending state so these PRs appear under "Needs Your Review"
- Actual submitted reviews override the pending state

## Test plan

- [x] All 39 existing + 2 new unit tests pass (`npx nx test vcs-github`)
- [ ] Manual: request a review from yourself on a PR, verify it shows in the reviews panel