### PR TITLE
fix: include GitHub review requests in reviews panel

### DIFF
--- a/libs/tmux-manager/package.json
+++ b/libs/tmux-manager/package.json
@@ -3,17 +3,15 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
-    "./package.json": "./package.json",
     ".": {
-      "@kirby/source": "./src/index.ts",
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
   },
   "nx": {
     "name": "tmux-manager"

--- a/libs/vcs/github/src/lib/provider.spec.ts
+++ b/libs/vcs/github/src/lib/provider.spec.ts
@@ -297,6 +297,7 @@ describe('githubProvider', () => {
                 reviews: {
                   nodes: [{ author: { login: 'bob' }, state: 'APPROVED' }],
                 },
+                reviewRequests: { nodes: [] },
                 reviewThreads: {
                   nodes: [
                     { isResolved: false },
@@ -323,6 +324,7 @@ describe('githubProvider', () => {
                 author: { login: 'alice' },
                 isDraft: true,
                 reviews: { nodes: [] },
+                reviewRequests: { nodes: [] },
                 reviewThreads: { nodes: [] },
                 commits: {
                   nodes: [
@@ -405,6 +407,7 @@ describe('githubProvider', () => {
                 author: { login: 'user' },
                 isDraft: false,
                 reviews: { nodes: [] },
+                reviewRequests: { nodes: [] },
                 reviewThreads: { nodes: [] },
                 commits: {
                   nodes: [{ commit: { statusCheckRollup: null } }],
@@ -429,6 +432,7 @@ describe('githubProvider', () => {
                 author: { login: 'user' },
                 isDraft: false,
                 reviews: { nodes: [] },
+                reviewRequests: { nodes: [] },
                 reviewThreads: { nodes: [] },
                 commits: {
                   nodes: [

--- a/libs/vcs/github/src/lib/provider.ts
+++ b/libs/vcs/github/src/lib/provider.ts
@@ -137,6 +137,14 @@ const SEARCH_PRS_QUERY = `
               state
             }
           }
+          reviewRequests(first: 20) {
+            nodes {
+              requestedReviewer {
+                ... on User { login }
+                ... on Team { name }
+              }
+            }
+          }
           reviewThreads(first: 100) {
             nodes { isResolved }
           }
@@ -165,6 +173,11 @@ interface SearchPrNode {
   isDraft: boolean;
   reviews: {
     nodes: Array<{ author: { login: string }; state: string }>;
+  };
+  reviewRequests: {
+    nodes: Array<{
+      requestedReviewer: { login?: string; name?: string };
+    }>;
   };
   reviewThreads: {
     nodes: Array<{ isResolved: boolean }>;
@@ -209,6 +222,21 @@ export function mapRollupState(
 
 function transformSearchNode(node: SearchPrNode): PullRequestInfo {
   const reviewers = latestReviewPerUser(node.reviews.nodes);
+
+  // Merge requested reviewers who haven't submitted a review yet
+  const reviewedLogins = new Set(
+    reviewers.map((r) => r.identifier.toLowerCase())
+  );
+  for (const req of node.reviewRequests.nodes) {
+    const login = req.requestedReviewer.login;
+    if (login && !reviewedLogins.has(login.toLowerCase())) {
+      reviewers.push({
+        displayName: login,
+        identifier: login,
+        decision: 'no-response',
+      });
+    }
+  }
 
   const unresolvedCount = node.reviewThreads.nodes.filter(
     (t) => !t.isResolved


### PR DESCRIPTION
## Summary

- Query `reviewRequests` field from GitHub GraphQL API alongside existing `reviews` field
- Merge requested reviewers who haven't yet submitted a review into the reviewers array with `no-response` decision, so PRs needing our review appear in "Needs Your Review"
- Fix `@kirby/tmux-manager` package exports to point at source `.ts` files (matching other libs), so `nx serve cli` works without a build step

## Test plan

- [x] `npx nx test vcs-github` — all 37 tests pass
- [ ] `npx nx serve cli` — verify PRs #2 and #3 appear in "Needs Your Review"