### PR TITLE
chore: remove unused tsconfig references and normalize lockfile

### DIFF
--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -8,21 +8,5 @@
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [],
-  "references": [
-    {
-      "path": "../../libs/vcs/core/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/vcs/azure-devops/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/vcs/github/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/tmux-control/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/tmux-manager/tsconfig.lib.json"
-    }
-  ]
+  "references": []
 }

--- a/libs/vcs/azure-devops/tsconfig.lib.json
+++ b/libs/vcs/azure-devops/tsconfig.lib.json
@@ -10,11 +10,7 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": [
-    {
-      "path": "../core/tsconfig.lib.json"
-    }
-  ],
+  "references": [],
   "exclude": [
     "vite.config.ts",
     "vite.config.mts",

--- a/libs/vcs/github/tsconfig.lib.json
+++ b/libs/vcs/github/tsconfig.lib.json
@@ -10,11 +10,7 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": [
-    {
-      "path": "../core/tsconfig.lib.json"
-    }
-  ],
+  "references": [],
   "exclude": [
     "vite.config.ts",
     "vite.config.mts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10017,6 +10017,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10034,6 +10035,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10051,6 +10053,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10068,6 +10071,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10085,6 +10089,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10102,6 +10107,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10119,6 +10125,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10136,6 +10143,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10153,6 +10161,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10170,6 +10179,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10187,6 +10197,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10204,6 +10215,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10221,6 +10233,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10238,6 +10251,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10255,6 +10269,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10272,6 +10287,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10287,6 +10303,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10304,6 +10321,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10321,6 +10339,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10338,6 +10357,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10355,6 +10375,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10372,6 +10393,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10389,6 +10411,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## Summary

- Remove stale `references` from tsconfig.lib.json files (libs export source `.ts` files directly, no `tsc --build` needed)
- Normalize package-lock.json