### PR TITLE
fix: sync with origin now updates local master when HEAD is on it

### DIFF
--- a/apps/cli/src/input-handlers.ts
+++ b/apps/cli/src/input-handlers.ts
@@ -509,11 +509,11 @@ export function handleSidebarInput(
         ctx.flashStatus('No worktree found for selected session');
         return;
       }
-      ctx.flashStatus('Updating from master...');
+      ctx.flashStatus('Updating from origin...');
       const rebaseMessages = {
-        success: 'Rebased onto master successfully',
+        success: 'Rebased onto origin successfully',
         conflict: 'Conflicts detected — rebase aborted',
-        error: 'Failed to fetch origin/master',
+        error: 'Failed to fetch from origin',
       } as const;
       ctx.flashStatus(rebaseMessages[await rebaseOntoMaster(wt.path)]);
     });

--- a/libs/tmux-manager/src/lib/worktree-integration.spec.ts
+++ b/libs/tmux-manager/src/lib/worktree-integration.spec.ts
@@ -17,6 +17,7 @@ import {
   fastForwardMaster,
   countConflicts,
   rebaseOntoMaster,
+  resetMainBranchCache,
 } from './worktree.js';
 
 // Collect temp dirs for cleanup
@@ -99,6 +100,7 @@ function setupRemoteAndClone(): {
 
 beforeEach(() => {
   originalCwd = process.cwd();
+  resetMainBranchCache();
 });
 
 afterEach(() => {
@@ -251,6 +253,47 @@ describe('integration: fastForwardMaster', () => {
     execSync('git checkout -b temp-branch', { cwd: cloneDir, stdio: 'pipe' });
 
     // Record local master before fast-forward
+    const localBefore = execSync('git rev-parse master', {
+      cwd: cloneDir,
+      encoding: 'utf8',
+    }).trim();
+
+    const result = await fastForwardMaster();
+    expect(result).toBe(true);
+
+    // Local master should now be ahead of where it was
+    const localAfter = execSync('git rev-parse master', {
+      cwd: cloneDir,
+      encoding: 'utf8',
+    }).trim();
+    expect(localAfter).not.toBe(localBefore);
+  });
+
+  it('should fast-forward when HEAD IS on master (the bug case)', async () => {
+    const { remoteDir, cloneDir } = setupRemoteAndClone();
+    process.chdir(cloneDir);
+
+    // Add a commit to the remote via a separate working copy
+    const pushDir = mkdtempSync(join(tmpdir(), 'worktree-push-'));
+    tempDirs.push(pushDir);
+    execSync(`git clone "${remoteDir}" "${pushDir}"`, { stdio: 'pipe' });
+    execSync('git config user.email "other@example.com"', {
+      cwd: pushDir,
+      stdio: 'pipe',
+    });
+    execSync('git config user.name "Other User"', {
+      cwd: pushDir,
+      stdio: 'pipe',
+    });
+    writeFileSync(join(pushDir, 'new-file.txt'), 'content');
+    execSync('git add .', { cwd: pushDir, stdio: 'pipe' });
+    execSync('git commit -m "remote commit"', {
+      cwd: pushDir,
+      stdio: 'pipe',
+    });
+    execSync('git push', { cwd: pushDir, stdio: 'pipe' });
+
+    // Stay on master — do NOT switch away (this is the bug scenario)
     const localBefore = execSync('git rev-parse master', {
       cwd: cloneDir,
       encoding: 'utf8',

--- a/libs/tmux-manager/src/lib/worktree.spec.ts
+++ b/libs/tmux-manager/src/lib/worktree.spec.ts
@@ -11,6 +11,8 @@ import {
   fastForwardMaster,
   countConflicts,
   rebaseOntoMaster,
+  getMainBranch,
+  resetMainBranchCache,
 } from './worktree.js';
 import { existsSync } from 'node:fs';
 
@@ -33,6 +35,7 @@ function resolve(stdout = '') {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetMainBranchCache();
 });
 
 describe('listBranches', () => {
@@ -285,9 +288,12 @@ describe('listWorktrees', () => {
 
 describe('rebaseOntoMaster', () => {
   it('should return success when fetch and rebase both succeed', async () => {
-    mockExec.mockResolvedValueOnce(resolve()).mockResolvedValueOnce(resolve());
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockResolvedValueOnce(resolve()) // fetch
+      .mockResolvedValueOnce(resolve()); // rebase
     expect(await rebaseOntoMaster('/path/to/worktree')).toBe('success');
-    expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExec).toHaveBeenCalledTimes(3);
     expect(mockExec).toHaveBeenCalledWith(
       'git -C "/path/to/worktree" fetch origin master',
       { encoding: 'utf8' }
@@ -299,18 +305,21 @@ describe('rebaseOntoMaster', () => {
   });
 
   it('should return error when fetch fails', async () => {
-    mockExec.mockRejectedValueOnce(new Error('fetch failed'));
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockRejectedValueOnce(new Error('fetch failed'));
     expect(await rebaseOntoMaster('/path/to/worktree')).toBe('error');
-    expect(mockExec).toHaveBeenCalledTimes(1);
+    expect(mockExec).toHaveBeenCalledTimes(2); // getMainBranch + fetch
   });
 
   it('should return conflict and abort when rebase fails', async () => {
     mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
       .mockResolvedValueOnce(resolve()) // fetch succeeds
       .mockRejectedValueOnce(new Error('conflict')) // rebase fails
       .mockResolvedValueOnce(resolve()); // abort succeeds
     expect(await rebaseOntoMaster('/path/to/worktree')).toBe('conflict');
-    expect(mockExec).toHaveBeenCalledTimes(3);
+    expect(mockExec).toHaveBeenCalledTimes(4);
     expect(mockExec).toHaveBeenLastCalledWith(
       'git -C "/path/to/worktree" rebase --abort',
       { encoding: 'utf8' }
@@ -319,11 +328,12 @@ describe('rebaseOntoMaster', () => {
 
   it('should return conflict even when abort also fails', async () => {
     mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
       .mockResolvedValueOnce(resolve()) // fetch succeeds
       .mockRejectedValueOnce(new Error('conflict')) // rebase fails
       .mockRejectedValueOnce(new Error('abort failed')); // abort fails
     expect(await rebaseOntoMaster('/path/to/worktree')).toBe('conflict');
-    expect(mockExec).toHaveBeenCalledTimes(3);
+    expect(mockExec).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -369,11 +379,60 @@ describe('listAllBranches', () => {
   });
 });
 
+describe('getMainBranch', () => {
+  it('should detect main branch from symbolic-ref', async () => {
+    mockExec.mockResolvedValueOnce(resolve('refs/remotes/origin/master'));
+    expect(await getMainBranch()).toBe('master');
+    expect(mockExec).toHaveBeenCalledWith(
+      'git symbolic-ref refs/remotes/origin/HEAD',
+      { encoding: 'utf8' }
+    );
+  });
+
+  it('should detect "main" from symbolic-ref', async () => {
+    mockExec.mockResolvedValueOnce(resolve('refs/remotes/origin/main'));
+    expect(await getMainBranch()).toBe('main');
+  });
+
+  it('should fall back to rev-parse when symbolic-ref fails', async () => {
+    mockExec
+      .mockRejectedValueOnce(new Error('no symbolic-ref'))
+      .mockResolvedValueOnce(resolve());
+    expect(await getMainBranch()).toBe('master');
+    expect(mockExec).toHaveBeenCalledWith(
+      'git rev-parse --verify --quiet origin/master',
+      { encoding: 'utf8' }
+    );
+  });
+
+  it('should default to "main" when both symbolic-ref and rev-parse fail', async () => {
+    mockExec
+      .mockRejectedValueOnce(new Error('no symbolic-ref'))
+      .mockRejectedValueOnce(new Error('no origin/master'));
+    expect(await getMainBranch()).toBe('main');
+  });
+
+  it('should return cached value on subsequent calls', async () => {
+    mockExec.mockResolvedValueOnce(resolve('refs/remotes/origin/master'));
+    await getMainBranch();
+    // Second call should not invoke exec again
+    expect(await getMainBranch()).toBe('master');
+    expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('fastForwardMaster', () => {
-  it('should return true when fetch and branch update both succeed', async () => {
-    mockExec.mockResolvedValueOnce(resolve()).mockResolvedValueOnce(resolve());
+  it('should use branch -f when HEAD is not on main branch', async () => {
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockResolvedValueOnce(resolve()) // fetch
+      .mockResolvedValueOnce(resolve('feature/foo\n')) // symbolic-ref HEAD
+      .mockResolvedValueOnce(resolve()); // branch -f
     expect(await fastForwardMaster()).toBe(true);
     expect(mockExec).toHaveBeenCalledWith('git fetch origin master', {
+      encoding: 'utf8',
+    });
+    expect(mockExec).toHaveBeenCalledWith('git symbolic-ref --short HEAD', {
       encoding: 'utf8',
     });
     expect(mockExec).toHaveBeenCalledWith(
@@ -382,23 +441,50 @@ describe('fastForwardMaster', () => {
     );
   });
 
+  it('should use merge --ff-only when HEAD IS on main branch', async () => {
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockResolvedValueOnce(resolve()) // fetch
+      .mockResolvedValueOnce(resolve('master\n')) // symbolic-ref HEAD
+      .mockResolvedValueOnce(resolve()); // merge --ff-only
+    expect(await fastForwardMaster()).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(
+      'git merge --ff-only origin/master',
+      { encoding: 'utf8' }
+    );
+  });
+
   it('should return false when fetch fails', async () => {
-    mockExec.mockRejectedValueOnce(new Error('fetch failed'));
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockRejectedValueOnce(new Error('fetch failed'));
     expect(await fastForwardMaster()).toBe(false);
-    expect(mockExec).toHaveBeenCalledTimes(1);
+    expect(mockExec).toHaveBeenCalledTimes(2); // getMainBranch + fetch
   });
 
   it('should return false when branch update fails', async () => {
     mockExec
-      .mockResolvedValueOnce(resolve())
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockResolvedValueOnce(resolve()) // fetch
+      .mockResolvedValueOnce(resolve('feature/foo\n')) // symbolic-ref HEAD
       .mockRejectedValueOnce(new Error('branch update failed'));
+    expect(await fastForwardMaster()).toBe(false);
+  });
+
+  it('should return false when HEAD is detached and branch -f fails', async () => {
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockResolvedValueOnce(resolve()) // fetch
+      .mockRejectedValueOnce(new Error('not a symbolic ref')); // symbolic-ref HEAD fails (detached)
     expect(await fastForwardMaster()).toBe(false);
   });
 });
 
 describe('countConflicts', () => {
   it('should return 0 for clean merge', async () => {
-    mockExec.mockResolvedValueOnce(resolve('abc123'));
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockResolvedValueOnce(resolve('abc123'));
     expect(await countConflicts('feature/clean')).toBe(0);
     expect(mockExec).toHaveBeenCalledWith(
       'git merge-tree --write-tree origin/master "feature/clean"',
@@ -418,12 +504,16 @@ describe('countConflicts', () => {
       'CONFLICT (content): Merge conflict in src/file2.ts',
       '',
     ].join('\n');
-    mockExec.mockRejectedValueOnce(err);
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockRejectedValueOnce(err);
     expect(await countConflicts('feature/conflicts')).toBe(2);
   });
 
   it('should return 0 for non-conflict errors', async () => {
-    mockExec.mockRejectedValueOnce(new Error('unknown error'));
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockRejectedValueOnce(new Error('unknown error'));
     expect(await countConflicts('feature/broken')).toBe(0);
   });
 
@@ -434,7 +524,9 @@ describe('countConflicts', () => {
     };
     err.code = 1;
     err.stdout = 'abc123\n';
-    mockExec.mockRejectedValueOnce(err);
+    mockExec
+      .mockResolvedValueOnce(resolve('refs/remotes/origin/master')) // getMainBranch
+      .mockRejectedValueOnce(err);
     expect(await countConflicts('feature/weird')).toBe(0);
   });
 });

--- a/libs/tmux-manager/src/lib/worktree.ts
+++ b/libs/tmux-manager/src/lib/worktree.ts
@@ -8,6 +8,38 @@ import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { exec } from './exec.js';
 
+let cachedMainBranch: string | null = null;
+
+/** Auto-detect the main branch name (master or main) and cache it. */
+export async function getMainBranch(): Promise<string> {
+  if (cachedMainBranch) return cachedMainBranch;
+  try {
+    // git symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/master"
+    const { stdout } = await exec('git symbolic-ref refs/remotes/origin/HEAD', {
+      encoding: 'utf8',
+    });
+    cachedMainBranch = stdout.trim().split('/').pop()!;
+    return cachedMainBranch;
+  } catch {
+    // Fallback: check which remote branch exists
+    try {
+      await exec('git rev-parse --verify --quiet origin/master', {
+        encoding: 'utf8',
+      });
+      cachedMainBranch = 'master';
+      return cachedMainBranch;
+    } catch {
+      cachedMainBranch = 'main';
+      return cachedMainBranch;
+    }
+  }
+}
+
+/** Reset the cached main branch name (for testing). */
+export function resetMainBranchCache(): void {
+  cachedMainBranch = null;
+}
+
 export interface WorktreeInfo {
   path: string;
   branch: string; // short branch name (no refs/heads/)
@@ -210,25 +242,42 @@ export async function listWorktrees(): Promise<WorktreeInfo[]> {
   }
 }
 
-/** Fast-forward local master to origin/master. Returns true on success. */
-export async function fastForwardMaster(): Promise<boolean> {
+/** Fast-forward local main branch to match origin. Returns true on success. */
+export async function fastForwardMainBranch(): Promise<boolean> {
+  const main = await getMainBranch();
   try {
-    await exec('git fetch origin master', { encoding: 'utf8' });
-    await exec('git branch -f master origin/master', { encoding: 'utf8' });
+    await exec(`git fetch origin ${main}`, { encoding: 'utf8' });
+  } catch {
+    return false;
+  }
+  try {
+    const { stdout } = await exec('git symbolic-ref --short HEAD', {
+      encoding: 'utf8',
+    });
+    if (stdout.trim() === main) {
+      // HEAD is on the main branch — use merge --ff-only instead
+      await exec(`git merge --ff-only origin/${main}`, { encoding: 'utf8' });
+    } else {
+      await exec(`git branch -f ${main} origin/${main}`, { encoding: 'utf8' });
+    }
     return true;
   } catch {
     return false;
   }
 }
 
+/** @deprecated Use fastForwardMainBranch instead */
+export const fastForwardMaster = fastForwardMainBranch;
+
 /**
- * Count conflicting files between a branch and origin/master.
+ * Count conflicting files between a branch and origin's main branch.
  * Uses `git merge-tree --write-tree` (Git 2.38+).
  * Returns 0 if no conflicts.
  */
 export async function countConflicts(branch: string): Promise<number> {
+  const main = await getMainBranch();
   try {
-    await exec(`git merge-tree --write-tree origin/master "${branch}"`, {
+    await exec(`git merge-tree --write-tree origin/${main} "${branch}"`, {
       encoding: 'utf8',
     });
     return 0; // clean merge — no conflicts
@@ -255,21 +304,22 @@ export async function deleteBranch(branch: string): Promise<boolean> {
 }
 
 /**
- * Fetch origin/master and rebase the worktree's branch onto it.
+ * Fetch origin's main branch and rebase the worktree's branch onto it.
  * If conflicts arise, the rebase is automatically aborted.
  */
 export async function rebaseOntoMaster(
   worktreePath: string
 ): Promise<'success' | 'conflict' | 'error'> {
+  const main = await getMainBranch();
   try {
-    await exec(`git -C "${worktreePath}" fetch origin master`, {
+    await exec(`git -C "${worktreePath}" fetch origin ${main}`, {
       encoding: 'utf8',
     });
   } catch {
     return 'error';
   }
   try {
-    await exec(`git -C "${worktreePath}" rebase origin/master`, {
+    await exec(`git -C "${worktreePath}" rebase origin/${main}`, {
       encoding: 'utf8',
     });
     return 'success';


### PR DESCRIPTION
## Summary

- `fastForwardMaster()` silently failed when HEAD was on the main branch because `git branch -f` refuses to update the checked-out branch. Now detects this case and uses `git merge --ff-only` instead.
- Adds `getMainBranch()` helper that auto-detects `master` vs `main` (with caching), replacing all hardcoded `master` references in `fastForwardMaster`, `countConflicts`, and `rebaseOntoMaster`.
- Updates UI status messages to say "origin" instead of "master".

## Test plan

- [x] 87 unit + integration tests pass (`npx nx test tmux-manager`)
- [x] New integration test covers the exact bug scenario (fast-forward while HEAD is on master)
- [ ] Manual: `npx nx serve cli`, press `g`, verify `git log master` is up to date