### PR TITLE
fix: correct session selection after creation in sorted sidebar

### DIFF
--- a/.claude/agent-memory/senior-ink-reviewer/MEMORY.md
+++ b/.claude/agent-memory/senior-ink-reviewer/MEMORY.md
@@ -21,7 +21,7 @@
 - **main.tsx slimmed down**: ~136 lines, delegates to SessionsTab and ReviewsTab screen components
 - **pty-registry.ts**: module-level mutable Map singleton, no React integration
 - **No error boundaries** -- unhandled error crashes entire TUI
-- **Only 1 test file** for cli app: `pr-utils.spec.ts`
+- **Test files** for cli app: `pr-utils.spec.ts`, `session-sort.spec.ts`
 - **No resize listener** -- `useStdout().stdout.rows/columns` doesn't update on resize
 
 ## Ink Patterns
@@ -37,6 +37,7 @@
 
 - Shell injection risk in git functions using string interpolation
 - Stale closures in event handlers -- use functional setState form
+- Stale closure risk in `findSortedIndex` useCallback (closes over sessionPrMap): works by accident because PR data doesn't refresh in same async flow as session creation. Document or pass explicitly.
 - Duplicated logic (branch filtering computed in both input handler and BranchPicker)
 - No useWindowSize() for terminal resize
 
@@ -45,3 +46,4 @@
 - 2026-02-25: Reviewed perf async conversion + serve target cleanup
 - 2026-02-26: Reviewed xterm-headless removal, self-managed worktrees feature
 - 2026-03-07: Full codebase review of apps/cli/src/ -- see detailed findings in review output
+- 2026-03-17: Session sort bug fix review -- sorted index extracted to `utils/session-sort.ts`, stale closure concern flagged

--- a/apps/cli-e2e/src/session-sort-selection.test.ts
+++ b/apps/cli-e2e/src/session-sort-selection.test.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@microsoft/tui-test';
+import type { Terminal } from '@microsoft/tui-test/lib/terminal/term.js';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { registerCleanup } from './setup/git-repo.js';
+import { TEST_REPO } from './setup/constants.js';
+
+const hasGhToken = !!process.env.GH_TOKEN;
+
+// ── Module-scope setup ─────────────────────────────────────────────
+const mainJs = resolve('../cli/dist/main.js');
+
+const cloneDir = mkdtempSync(join(tmpdir(), 'kirby-sort-clone-'));
+const fakeHome = mkdtempSync(join(tmpdir(), 'kirby-sort-home-'));
+const logFile = join(tmpdir(), 'kirby-sort-debug.log');
+registerCleanup(cloneDir);
+registerCleanup(fakeHome);
+
+if (hasGhToken) {
+  // 1. Clone sandbox repo (all branches needed for branch picker)
+  //    Use HTTPS URL directly — gh repo clone may default to SSH which can be blocked.
+  const token = process.env.GH_TOKEN;
+  execSync(
+    `git clone "https://x-access-token:${token}@github.com/${TEST_REPO}.git" "${cloneDir}"`,
+    { stdio: 'pipe' }
+  );
+
+  // 2. Configure git identity
+  execSync('git config user.email "e2e@kirby.dev"', {
+    cwd: cloneDir,
+    stdio: 'pipe',
+  });
+  execSync('git config user.name "Kirby E2E"', {
+    cwd: cloneDir,
+    stdio: 'pipe',
+  });
+
+  // 4. Write global config with aiCommand: "cat" to avoid needing claude binary
+  const kirbyDir = join(fakeHome, '.kirby');
+  mkdirSync(kirbyDir, { recursive: true });
+  writeFileSync(
+    join(kirbyDir, 'config.json'),
+    JSON.stringify({ aiCommand: 'cat' }),
+    'utf-8'
+  );
+}
+
+// ── Helper: create a session via the branch picker UI ──────────────
+async function createSessionViaBranchPicker(
+  terminal: Terminal,
+  branchFilter: string,
+  sessionName: string
+) {
+  // Open branch picker
+  terminal.write('c');
+  await expect(
+    terminal.getByText('Branch Picker', { strict: false })
+  ).toBeVisible();
+
+  // Type the filter text
+  terminal.write(branchFilter);
+
+  // Wait for the filter to be reflected in the branch picker title.
+  // The title renders as "Branch Picker / {filter}" when a filter is active.
+  // This is the only reliable signal that React has committed the filter state,
+  // so the filtered branch list is correct when Enter is pressed.
+  await expect(
+    terminal.getByText(`/ ${branchFilter}`, { strict: false })
+  ).toBeVisible();
+
+  // Press Enter to create
+  terminal.write('\r');
+
+  // Wait for session to appear in sidebar
+  await expect(terminal.getByText(sessionName, { strict: false })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+// ── Configure tui-test ─────────────────────────────────────────────
+test.use({
+  rows: 60,
+  columns: 120,
+  program: {
+    file: 'node',
+    args: [mainJs, cloneDir],
+  },
+  env: {
+    ...process.env,
+    HOME: fakeHome,
+    TERM: 'xterm-256color',
+    KIRBY_LOG: logFile,
+  },
+});
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test.when(
+  hasGhToken,
+  'selects correct session after branch picker creation in sorted sidebar',
+  async ({ terminal }) => {
+    // 1. Wait for Kirby to render
+    await expect(
+      terminal.getByText('Worktree Sessions', { strict: false })
+    ).toBeVisible();
+
+    // 2. Create sessions in an order that DIFFERS from PR-sorted order.
+    //    Sorted order (desc PR ID): ai-solver(#39), undo(#38), color(#37)
+    //    Creation order:            color(#37), ai-solver(#39), undo(#38)
+    //
+    //    This makes the raw list indices differ from sorted indices:
+    //      Raw (creation order): [color=0, ai-solver=1, undo=2]
+    //      Sorted (desc PR):    [ai-solver=0, undo=1, color=2]
+    //
+    //    Buggy findIndex('undo') = 2 (raw) → sorted[2] = color (WRONG)
+    //    Fixed findSortedIndex('undo') = 1 → sorted[1] = undo (CORRECT)
+
+    await createSessionViaBranchPicker(
+      terminal,
+      'fixture/add-color',
+      'fixture-add-color-support'
+    );
+
+    await createSessionViaBranchPicker(
+      terminal,
+      'fixture/add-ai-solver',
+      'fixture-add-ai-solver'
+    );
+
+    // 3. Wait for PR data to load (PR badges should appear)
+    await expect(terminal.getByText('#39', { strict: false })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // 4. Create the third session: fixture/add-undo-feature (PR #38)
+    //    This is the session that exposes the bug.
+    await createSessionViaBranchPicker(
+      terminal,
+      'fixture/add-undo',
+      'fixture-add-undo-feature'
+    );
+
+    // 5. The selection marker (›) should be on the newly created session
+    await expect(
+      terminal.getByText(/›.*fixture-add-undo-feature/g, { strict: false })
+    ).toBeVisible();
+
+    // 6. Confirm the marker is NOT on the wrong session (color-support)
+    expect(
+      terminal.getByText(/›.*fixture-add-color-support/g, { strict: false })
+    ).not.toBeVisible();
+  }
+);

--- a/apps/cli/src/context/SessionContext.tsx
+++ b/apps/cli/src/context/SessionContext.tsx
@@ -18,6 +18,10 @@ import { useConflictCounts } from '../hooks/useConflictCounts.js';
 import { useConfig } from './ConfigContext.js';
 import { useAppState } from './AppStateContext.js';
 import type { AgentSession } from '../types.js';
+import {
+  sortSessionsByPrId,
+  findSortedSessionIndex,
+} from '../utils/session-sort.js';
 
 /**
  * All session-related state: worktree sessions, PR data, and derived lookups.
@@ -37,6 +41,7 @@ export interface SessionContextValue {
   statusMessage: string | null;
   flashStatus: (msg: string) => void;
   refreshSessions: () => Promise<AgentSession[]>;
+  findSortedIndex: (sessions: AgentSession[], name: string) => number;
   performDelete: (sessionName: string, branch: string) => Promise<void>;
 
   // ── PR / VCS data ──
@@ -116,13 +121,16 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     [prMap]
   );
 
-  const sortedSessions = useMemo(() => {
-    return [...sessionMgr.sessions].sort((a, b) => {
-      const idA = sessionPrMap.get(a.name)?.id ?? -Infinity;
-      const idB = sessionPrMap.get(b.name)?.id ?? -Infinity;
-      return idB - idA;
-    });
-  }, [sessionMgr.sessions, sessionPrMap]);
+  const sortedSessions = useMemo(
+    () => sortSessionsByPrId(sessionMgr.sessions, sessionPrMap),
+    [sessionMgr.sessions, sessionPrMap]
+  );
+
+  const findSortedIdx = useCallback(
+    (rawSessions: AgentSession[], name: string): number =>
+      findSortedSessionIndex(rawSessions, sessionPrMap, name),
+    [sessionPrMap]
+  );
 
   const totalItems = sortedSessions.length + orphanPrs.length;
   const clampedSelectedIndex =
@@ -142,6 +150,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       statusMessage: sessionMgr.statusMessage,
       flashStatus: sessionMgr.flashStatus,
       refreshSessions: sessionMgr.refreshSessions,
+      findSortedIndex: findSortedIdx,
       performDelete: sessionMgr.performDelete,
       prMap,
       prError,
@@ -163,6 +172,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     }),
     [
       sessionMgr,
+      findSortedIdx,
       prMap,
       prError,
       refreshPr,

--- a/apps/cli/src/context/SessionContext.tsx
+++ b/apps/cli/src/context/SessionContext.tsx
@@ -126,6 +126,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     [sessionMgr.sessions, sessionPrMap]
   );
 
+  // Safe to close over sessionPrMap: it only changes on PR refresh (usePrData),
+  // never during session creation, so the map is current when callers invoke this
+  // right after refreshSessions().
   const findSortedIdx = useCallback(
     (rawSessions: AgentSession[], name: string): number =>
       findSortedSessionIndex(rawSessions, sessionPrMap, name),

--- a/apps/cli/src/screens/sessions/sessions-input.ts
+++ b/apps/cli/src/screens/sessions/sessions-input.ts
@@ -140,7 +140,7 @@ export function handleBranchPickerInput(
             ctx.config.config
           );
           const updated = await ctx.sessions.refreshSessions();
-          const idx = updated.findIndex((s) => s.name === sessionName);
+          const idx = ctx.sessions.findSortedIndex(updated, sessionName);
           if (idx >= 0) ctx.sessions.setSelectedIndex(idx);
         }
       });
@@ -368,7 +368,7 @@ export function handleSessionsSidebarInput(
             ctx.config.config
           );
           const updated = await ctx.sessions.refreshSessions();
-          const idx = updated.findIndex((s) => s.name === sessionName);
+          const idx = ctx.sessions.findSortedIndex(updated, sessionName);
           if (idx >= 0) ctx.sessions.setSelectedIndex(idx);
         }
       });

--- a/apps/cli/src/utils/session-sort.spec.ts
+++ b/apps/cli/src/utils/session-sort.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import type { PullRequestInfo } from '@kirby/vcs-core';
+import type { AgentSession } from '../types.js';
+import { sortSessionsByPrId, findSortedSessionIndex } from './session-sort.js';
+
+function makePrMap(entries: [string, number][]): Map<string, PullRequestInfo> {
+  const map = new Map<string, PullRequestInfo>();
+  for (const [name, id] of entries) {
+    map.set(name, {
+      id,
+      title: `PR #${id}`,
+      sourceBranch: name,
+      targetBranch: 'main',
+      url: '',
+      createdByIdentifier: '',
+      createdByDisplayName: '',
+    } as PullRequestInfo);
+  }
+  return map;
+}
+
+function sessions(...names: string[]): AgentSession[] {
+  return names.map((name) => ({ name, running: false }));
+}
+
+describe('sortSessionsByPrId', () => {
+  it('sorts sessions by PR ID descending', () => {
+    const prMap = makePrMap([
+      ['feature-a', 5],
+      ['feature-c', 10],
+    ]);
+    const sorted = sortSessionsByPrId(
+      sessions('feature-a', 'feature-b', 'feature-c'),
+      prMap
+    );
+    expect(sorted.map((s) => s.name)).toEqual([
+      'feature-c',
+      'feature-a',
+      'feature-b',
+    ]);
+  });
+
+  it('puts sessions without PRs at the end', () => {
+    const prMap = makePrMap([['has-pr', 1]]);
+    const sorted = sortSessionsByPrId(sessions('no-pr', 'has-pr'), prMap);
+    expect(sorted[0]!.name).toBe('has-pr');
+    expect(sorted[1]!.name).toBe('no-pr');
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(sortSessionsByPrId([], new Map())).toEqual([]);
+  });
+
+  it('does not mutate the original array', () => {
+    const original = sessions('a', 'b');
+    const prMap = makePrMap([['b', 10]]);
+    sortSessionsByPrId(original, prMap);
+    expect(original[0]!.name).toBe('a');
+  });
+});
+
+describe('findSortedSessionIndex', () => {
+  it('returns correct index for session with highest PR ID', () => {
+    const s = sessions('feature-a', 'feature-b', 'feature-c', 'feature-d');
+    const prMap = makePrMap([
+      ['feature-a', 5],
+      ['feature-c', 10],
+      ['feature-d', 15],
+    ]);
+    // Sorted: feature-d(15), feature-c(10), feature-a(5), feature-b(no PR)
+    expect(findSortedSessionIndex(s, prMap, 'feature-d')).toBe(0);
+    expect(findSortedSessionIndex(s, prMap, 'feature-c')).toBe(1);
+    expect(findSortedSessionIndex(s, prMap, 'feature-a')).toBe(2);
+    expect(findSortedSessionIndex(s, prMap, 'feature-b')).toBe(3);
+  });
+
+  it('returns -1 for non-existent session', () => {
+    expect(
+      findSortedSessionIndex(sessions('a'), new Map(), 'nonexistent')
+    ).toBe(-1);
+  });
+
+  it('reproduces the original bug scenario (orphan PR creation)', () => {
+    // Before fix: code used unsorted findIndex which would return 3
+    // After fix: sorted findIndex correctly returns 0
+    const s = sessions('feature-a', 'feature-b', 'feature-c', 'feature-d');
+    const prMap = makePrMap([
+      ['feature-a', 5],
+      ['feature-c', 10],
+      ['feature-d', 15], // newly created from orphan PR
+    ]);
+
+    // Bug: unsorted findIndex('feature-d') = 3
+    const buggyIndex = s.findIndex((x) => x.name === 'feature-d');
+    expect(buggyIndex).toBe(3);
+
+    // Fix: sorted findIndex('feature-d') = 0
+    const correctIndex = findSortedSessionIndex(s, prMap, 'feature-d');
+    expect(correctIndex).toBe(0);
+
+    // The buggy index would select feature-b in sorted view
+    const sorted = sortSessionsByPrId(s, prMap);
+    expect(sorted[buggyIndex]!.name).toBe('feature-b'); // wrong!
+    expect(sorted[correctIndex]!.name).toBe('feature-d'); // correct!
+  });
+});

--- a/apps/cli/src/utils/session-sort.spec.ts
+++ b/apps/cli/src/utils/session-sort.spec.ts
@@ -57,6 +57,21 @@ describe('sortSessionsByPrId', () => {
     sortSessionsByPrId(original, prMap);
     expect(original[0]!.name).toBe('a');
   });
+
+  it('preserves insertion order among sessions without PRs', () => {
+    const prMap = makePrMap([['has-pr', 1]]);
+    const sorted = sortSessionsByPrId(
+      sessions('z-no-pr', 'a-no-pr', 'has-pr', 'm-no-pr'),
+      prMap
+    );
+    // has-pr first, then the three PR-less in original order
+    expect(sorted.map((s) => s.name)).toEqual([
+      'has-pr',
+      'z-no-pr',
+      'a-no-pr',
+      'm-no-pr',
+    ]);
+  });
 });
 
 describe('findSortedSessionIndex', () => {

--- a/apps/cli/src/utils/session-sort.ts
+++ b/apps/cli/src/utils/session-sort.ts
@@ -10,9 +10,15 @@ export function sortSessionsByPrId(
   sessionPrMap: Map<string, PullRequestInfo>
 ): AgentSession[] {
   return [...sessions].sort((a, b) => {
-    const idA = sessionPrMap.get(a.name)?.id ?? -Infinity;
-    const idB = sessionPrMap.get(b.name)?.id ?? -Infinity;
-    return idB - idA;
+    const idA = sessionPrMap.get(a.name)?.id;
+    const idB = sessionPrMap.get(b.name)?.id;
+    // Both have PRs: sort descending by ID
+    if (idA != null && idB != null) return idB - idA;
+    // Only one has a PR: it sorts first
+    if (idA != null) return -1;
+    if (idB != null) return 1;
+    // Neither has a PR: preserve original order
+    return 0;
   });
 }
 

--- a/apps/cli/src/utils/session-sort.ts
+++ b/apps/cli/src/utils/session-sort.ts
@@ -1,0 +1,34 @@
+import type { AgentSession } from '../types.js';
+import type { PullRequestInfo } from '@kirby/vcs-core';
+
+/**
+ * Sort sessions by descending PR ID.
+ * Sessions without a PR mapping sort to the end (stable).
+ */
+export function sortSessionsByPrId(
+  sessions: AgentSession[],
+  sessionPrMap: Map<string, PullRequestInfo>
+): AgentSession[] {
+  return [...sessions].sort((a, b) => {
+    const idA = sessionPrMap.get(a.name)?.id ?? -Infinity;
+    const idB = sessionPrMap.get(b.name)?.id ?? -Infinity;
+    return idB - idA;
+  });
+}
+
+/**
+ * Find the index of a session by name in a PR-ID-sorted list.
+ *
+ * Use this instead of `sessions.findIndex(s => s.name === name)` when the
+ * result will be passed to `setSelectedIndex`, because the sidebar renders
+ * sessions in sorted (by PR ID) order, not insertion order.
+ */
+export function findSortedSessionIndex(
+  sessions: AgentSession[],
+  sessionPrMap: Map<string, PullRequestInfo>,
+  name: string
+): number {
+  return sortSessionsByPrId(sessions, sessionPrMap).findIndex(
+    (s) => s.name === name
+  );
+}


### PR DESCRIPTION
After creating a session (branch picker or orphan PR), the sidebar
highlighted the wrong session. The selected index was computed from
the unsorted session array but used against the PR-ID-sorted display
list, causing a mismatch.

Extract sort logic into session-sort.ts utility, expose findSortedIndex
on SessionContext, and use it at both creation call sites. Includes
unit tests that reproduce the exact bug scenario.

https://claude.ai/code/session_01DMvdxRTTppZWuwVSe7SZaa