### PR TITLE
UX refresh: titled borders, toasts, overlay modal, richer layout

### DIFF
--- a/.claude/agent-memory/senior-ink-reviewer/MEMORY.md
+++ b/.claude/agent-memory/senior-ink-reviewer/MEMORY.md
@@ -47,3 +47,4 @@
 - 2026-02-26: Reviewed xterm-headless removal, self-managed worktrees feature
 - 2026-03-07: Full codebase review of apps/cli/src/ -- see detailed findings in review output
 - 2026-03-17: Session sort bug fix review -- sorted index extracted to `utils/session-sort.ts`, stale closure concern flagged
+- 2026-04-13: Modal + Toast system review -- Toast has setTimeout leak + cap-evict timer leak; flagged Ink 6.8 inset props are dead code (not implemented in runtime). See [ink_6_8_inset_props.md](ink_6_8_inset_props.md).

--- a/.claude/agent-memory/senior-ink-reviewer/ink_6_8_inset_props.md
+++ b/.claude/agent-memory/senior-ink-reviewer/ink_6_8_inset_props.md
@@ -1,0 +1,19 @@
+---
+name: Ink 6.8 inset props (top/right/bottom/left) are not implemented
+description: Ink 6.8.0 readme advertises top/right/bottom/left for absolute positioning, but the runtime does not implement them. Affects modal/overlay patterns.
+type: reference
+---
+
+In Ink 6.8.0 (currently installed in this repo), `position="absolute"` is supported but the four inset offsets `top`/`right`/`bottom`/`left` are NOT yet implemented:
+
+- `node_modules/ink/build/styles.d.ts` — `Styles` type only declares `position`, no inset props
+- `node_modules/ink/build/components/Box.d.ts` — `Box` props omit them too
+- `node_modules/ink/build/styles.js` — layout pipeline only forwards `style.position` to Yoga via `setPositionType`; no code reads or forwards offsets
+
+The Ink readme on `master` advertises these props (lines ~970-996 of the upstream readme), but they haven't shipped to the released 6.8 runtime. Code that spreads `{...({ top: 0, left: 0 } as object)}` onto a Box is doing nothing — Ink simply ignores it.
+
+**Practical idiom for overlays in Ink 6.8:** `position="absolute"` + `width={termCols}` + `height={termRows}` to span the viewport, then use `alignItems`/`justifyContent` to push content inside the chosen anchor. This is the pattern Modal and ToastContainer use, and it's correct _for this version_. Switch to real inset offsets when Ink ships them.
+
+Also relevant: Ink 6.8.0 does NOT export `useWindowSize` (advertised in master readme but not in installed `index.d.ts`). The repo's `useTerminalDimensions` hook is necessary, not redundant.
+
+How to apply: when reviewing positioning code, check the installed Ink version's `styles.d.ts` and `styles.js` before recommending readme-advertised features. Watch for misleading comments that frame missing features as "type lag."

--- a/apps/cli-e2e/src/navigation-jump.test.ts
+++ b/apps/cli-e2e/src/navigation-jump.test.ts
@@ -56,10 +56,11 @@ if (hasGhToken) {
   pushBranch(cloneDir, branchA);
 
   // 4. Go back to default branch, then create branch B + push
-  const defaultBranch = execSync(
-    'git symbolic-ref refs/remotes/origin/HEAD',
-    { cwd: cloneDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
-  )
+  const defaultBranch = execSync('git symbolic-ref refs/remotes/origin/HEAD', {
+    cwd: cloneDir,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
     .trim()
     .replace('refs/remotes/origin/', '');
   execSync(`git checkout "${defaultBranch}"`, { cwd: cloneDir, stdio: 'pipe' });
@@ -159,9 +160,12 @@ test.when(
       terminal.write('j');
       await new Promise((r) => setTimeout(r, 500));
 
-      // 7. Verify session B is selected (› marker next to its name)
+      // 7. Verify session B is selected (◉ running / ◎ stopped indicator
+      //    next to its name).
       await expect(
-        terminal.getByText(new RegExp(`›.*${sessionB}`, 'g'), { strict: false })
+        terminal.getByText(new RegExp(`[◉◎].*${sessionB}`, 'g'), {
+          strict: false,
+        })
       ).toBeVisible();
 
       // 8. Create a PR for branch B — its ID will be higher than A's,
@@ -192,14 +196,14 @@ test.when(
 
       // Assert: selection should still be on session B's PR title
       await expect(
-        terminal.getByText(new RegExp(`›.*e2e: ${branchB}`, 'g'), {
+        terminal.getByText(new RegExp(`[◉◎].*e2e: ${branchB}`, 'g'), {
           strict: false,
         })
       ).toBeVisible();
 
       // Assert: selection should NOT be on session A
       expect(
-        terminal.getByText(new RegExp(`›.*e2e: ${branchA}`, 'g'), {
+        terminal.getByText(new RegExp(`[◉◎].*e2e: ${branchA}`, 'g'), {
           strict: false,
         })
       ).not.toBeVisible();

--- a/apps/cli-e2e/src/navigation-jump.test.ts
+++ b/apps/cli-e2e/src/navigation-jump.test.ts
@@ -12,6 +12,7 @@ import {
   closePullRequest,
   deleteRemoteBranch,
 } from './setup/github.js';
+import { sidebarLocator } from './setup/sidebar.js';
 
 const hasGhToken = !!process.env.GH_TOKEN;
 
@@ -160,13 +161,8 @@ test.when(
       terminal.write('j');
       await new Promise((r) => setTimeout(r, 500));
 
-      // 7. Verify session B is selected (◉ running / ◎ stopped indicator
-      //    next to its name).
-      await expect(
-        terminal.getByText(new RegExp(`[◉◎].*${sessionB}`, 'g'), {
-          strict: false,
-        })
-      ).toBeVisible();
+      // 7. Verify session B is selected
+      await expect(sidebarLocator(terminal, sessionB).selected()).toBeVisible();
 
       // 8. Create a PR for branch B — its ID will be higher than A's,
       //    so after refresh it sorts ABOVE A.
@@ -196,16 +192,12 @@ test.when(
 
       // Assert: selection should still be on session B's PR title
       await expect(
-        terminal.getByText(new RegExp(`[◉◎].*e2e: ${branchB}`, 'g'), {
-          strict: false,
-        })
+        sidebarLocator(terminal, `e2e: ${branchB}`).selected()
       ).toBeVisible();
 
       // Assert: selection should NOT be on session A
       expect(
-        terminal.getByText(new RegExp(`[◉◎].*e2e: ${branchA}`, 'g'), {
-          strict: false,
-        })
+        sidebarLocator(terminal, `e2e: ${branchA}`).selected()
       ).not.toBeVisible();
     } finally {
       // Cleanup GitHub resources (best-effort)

--- a/apps/cli-e2e/src/session-sort-selection.test.ts
+++ b/apps/cli-e2e/src/session-sort-selection.test.ts
@@ -137,13 +137,13 @@ test.when(
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-color',
-      /[◉◎●○].*Add color support/
+      /[◉◎●○].*Add color support/g
     );
 
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-ai-solver',
-      /[◉◎●○].*Add AI solver/
+      /[◉◎●○].*Add AI solver/g
     );
 
     // 3. Wait for PR data to load (PR badges should appear)
@@ -156,7 +156,7 @@ test.when(
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-undo',
-      /[◉◎●○].*Add undo feature/
+      /[◉◎●○].*Add undo feature/g
     );
 
     // 5. The selection indicator (◉ running, ◎ stopped) should be on the

--- a/apps/cli-e2e/src/session-sort-selection.test.ts
+++ b/apps/cli-e2e/src/session-sort-selection.test.ts
@@ -6,6 +6,7 @@ import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { registerCleanup } from './setup/git-repo.js';
 import { TEST_REPO } from './setup/constants.js';
+import { sidebarLocator } from './setup/sidebar.js';
 
 const hasGhToken = !!process.env.GH_TOKEN;
 
@@ -51,36 +52,23 @@ if (hasGhToken) {
 async function createSessionViaBranchPicker(
   terminal: Terminal,
   branchFilter: string,
-  waitFor: RegExp
+  waitForTitle: string
 ) {
-  // Open branch picker
   terminal.write('c');
   await expect(
     terminal.getByText('Branch Picker', { strict: false })
   ).toBeVisible();
 
-  // Type the filter text
   terminal.write(branchFilter);
 
-  // Wait for the filter to be reflected in the branch picker title.
-  // The title renders as "Branch Picker / {filter}" when a filter is active.
-  // This is the only reliable signal that React has committed the filter state,
-  // so the filtered branch list is correct when Enter is pressed.
   await expect(
     terminal.getByText(`/ ${branchFilter}`, { strict: false })
   ).toBeVisible();
 
-  // Press Enter to create
   terminal.write('\r');
 
-  // Wait for the session's row to appear in the sidebar with ANY running/
-  // selected-state icon preceding the title. The caller passes a regex like
-  // /[◉◎●○].*Title/ — we don't pin a specific icon because:
-  //   - `◉` / `◎` render when the row is selected (fresh sessions auto-select)
-  //   - `●` / `○` render once the next session is created and steals focus
-  //   - The PTY may or may not be running yet (running vs stopped).
-  // All four icons are valid "session exists" signals.
-  await expect(terminal.getByText(waitFor, { strict: false })).toBeVisible({
+  // Wait for the session row in any icon state (selected or not, running or not).
+  await expect(sidebarLocator(terminal, waitForTitle).any()).toBeVisible({
     timeout: 15_000,
   });
 }
@@ -123,27 +111,16 @@ test.when(
     //    Buggy findIndex('undo') = 2 (raw) → sorted[2] = color (WRONG)
     //    Fixed findSortedIndex('undo') = 1 → sorted[1] = undo (CORRECT)
 
-    // Each fixture branch already exists in the sidebar as a REVIEW PR
-    // (category "Waiting for Author" / "Approved by You"). When a session
-    // is created for that branch, `buildSidebarItems` keeps the row in
-    // its review section and the icon flips from `○` (review, no session)
-    // to one of ◉ / ◎ / ● depending on selection + running state.
-    //
-    // Icon map: ◉ selected+running, ◎ selected+stopped,
-    //           ● not-selected+running, ○ not-selected+stopped.
-    // The helper accepts any of the four — selection shifts as later
-    // sessions are created, and exact selection state is asserted
-    // separately below in steps 5 and 6.
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-color',
-      /[◉◎●○].*Add color support/g
+      'Add color support'
     );
 
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-ai-solver',
-      /[◉◎●○].*Add AI solver/g
+      'Add AI solver'
     );
 
     // 3. Wait for PR data to load (PR badges should appear)
@@ -156,20 +133,17 @@ test.when(
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-undo',
-      /[◉◎●○].*Add undo feature/g
+      'Add undo feature'
     );
 
-    // 5. The selection indicator (◉ running, ◎ stopped) should be on the
-    //    newly created session.
+    // 5. The selection indicator should be on the newly created session.
     await expect(
-      terminal.getByText(/[◉◎].*Add undo feature/g, { strict: false })
+      sidebarLocator(terminal, 'Add undo feature').selected()
     ).toBeVisible();
 
-    // 6. Confirm the indicator is NOT on the wrong session (color-support).
-    //    Color is de-selected now — should show the un-selected variants
-    //    (● running / ○ stopped), not [◉◎].
+    // 6. Confirm selection is NOT on the wrong session (color-support).
     expect(
-      terminal.getByText(/[◉◎].*Add color support/g, { strict: false })
+      sidebarLocator(terminal, 'Add color support').selected()
     ).not.toBeVisible();
   }
 );

--- a/apps/cli-e2e/src/session-sort-selection.test.ts
+++ b/apps/cli-e2e/src/session-sort-selection.test.ts
@@ -51,7 +51,7 @@ if (hasGhToken) {
 async function createSessionViaBranchPicker(
   terminal: Terminal,
   branchFilter: string,
-  waitForText: string
+  waitFor: RegExp
 ) {
   // Open branch picker
   terminal.write('c');
@@ -73,10 +73,14 @@ async function createSessionViaBranchPicker(
   // Press Enter to create
   terminal.write('\r');
 
-  // Wait for the running indicator (●) to appear next to the session.
-  // In the unified sidebar, sessions with PRs display the PR title, not
-  // the branch name, so we match on the indicator + title/name text.
-  await expect(terminal.getByText(waitForText, { strict: false })).toBeVisible({
+  // Wait for the session's row to appear in the sidebar with ANY running/
+  // selected-state icon preceding the title. The caller passes a regex like
+  // /[◉◎●○].*Title/ — we don't pin a specific icon because:
+  //   - `◉` / `◎` render when the row is selected (fresh sessions auto-select)
+  //   - `●` / `○` render once the next session is created and steals focus
+  //   - The PTY may or may not be running yet (running vs stopped).
+  // All four icons are valid "session exists" signals.
+  await expect(terminal.getByText(waitFor, { strict: false })).toBeVisible({
     timeout: 15_000,
   });
 }
@@ -119,19 +123,27 @@ test.when(
     //    Buggy findIndex('undo') = 2 (raw) → sorted[2] = color (WRONG)
     //    Fixed findSortedIndex('undo') = 1 → sorted[1] = undo (CORRECT)
 
-    // In the unified sidebar, sessions with PRs display the PR title,
-    // not the branch name. We wait for the running indicator (●) next to
-    // the PR title to confirm each session was created.
+    // Each fixture branch already exists in the sidebar as a REVIEW PR
+    // (category "Waiting for Author" / "Approved by You"). When a session
+    // is created for that branch, `buildSidebarItems` keeps the row in
+    // its review section and the icon flips from `○` (review, no session)
+    // to one of ◉ / ◎ / ● depending on selection + running state.
+    //
+    // Icon map: ◉ selected+running, ◎ selected+stopped,
+    //           ● not-selected+running, ○ not-selected+stopped.
+    // The helper accepts any of the four — selection shifts as later
+    // sessions are created, and exact selection state is asserted
+    // separately below in steps 5 and 6.
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-color',
-      '● Add color support'
+      /[◉◎●○].*Add color support/
     );
 
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-ai-solver',
-      '● Add AI solver'
+      /[◉◎●○].*Add AI solver/
     );
 
     // 3. Wait for PR data to load (PR badges should appear)
@@ -144,17 +156,20 @@ test.when(
     await createSessionViaBranchPicker(
       terminal,
       'fixture/add-undo',
-      '● Add undo feature'
+      /[◉◎●○].*Add undo feature/
     );
 
-    // 5. The selection marker (›) should be on the newly created session
+    // 5. The selection indicator (◉ running, ◎ stopped) should be on the
+    //    newly created session.
     await expect(
-      terminal.getByText(/›.*Add undo feature/g, { strict: false })
+      terminal.getByText(/[◉◎].*Add undo feature/g, { strict: false })
     ).toBeVisible();
 
-    // 6. Confirm the marker is NOT on the wrong session (color-support)
+    // 6. Confirm the indicator is NOT on the wrong session (color-support).
+    //    Color is de-selected now — should show the un-selected variants
+    //    (● running / ○ stopped), not [◉◎].
     expect(
-      terminal.getByText(/›.*Add color support/g, { strict: false })
+      terminal.getByText(/[◉◎].*Add color support/g, { strict: false })
     ).not.toBeVisible();
   }
 );

--- a/apps/cli-e2e/src/session-sort-selection.test.ts
+++ b/apps/cli-e2e/src/session-sort-selection.test.ts
@@ -67,6 +67,13 @@ async function createSessionViaBranchPicker(
 
   terminal.write('\r');
 
+  // Wait for the branch picker to close before proceeding. The Enter
+  // triggers an async worktree creation; setCreating(false) fires
+  // synchronously, so the branch picker title disappears first.
+  await expect(
+    terminal.getByText('Branch Picker', { strict: false })
+  ).not.toBeVisible();
+
   // Wait for the session row in any icon state (selected or not, running or not).
   await expect(sidebarLocator(terminal, waitForTitle).any()).toBeVisible({
     timeout: 15_000,

--- a/apps/cli-e2e/src/setup/sidebar.ts
+++ b/apps/cli-e2e/src/setup/sidebar.ts
@@ -1,0 +1,29 @@
+import type { Terminal } from '@microsoft/tui-test/lib/terminal/term.js';
+
+// Sidebar icon scheme (Sidebar.tsx):
+//   ◉  selected + running
+//   ◎  selected + stopped
+//   ●  not-selected + running
+//   ○  not-selected + stopped
+
+const SELECTED = '◉◎';
+const ANY = '◉◎●○';
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function selectedItem(title: string): RegExp {
+  return new RegExp(`[${SELECTED}].*${escapeRegExp(title)}`, 'g');
+}
+
+export function anyItem(title: string): RegExp {
+  return new RegExp(`[${ANY}].*${escapeRegExp(title)}`, 'g');
+}
+
+export function sidebarLocator(terminal: Terminal, title: string) {
+  return {
+    selected: () => terminal.getByText(selectedItem(title), { strict: false }),
+    any: () => terminal.getByText(anyItem(title), { strict: false }),
+  };
+}

--- a/apps/cli-e2e/src/sidebar-auto-hide.test.ts
+++ b/apps/cli-e2e/src/sidebar-auto-hide.test.ts
@@ -78,20 +78,23 @@ test.describe('Sidebar auto-hide', () => {
     );
 
     // 4. Tab → PTY starts, focus moves to terminal, sidebar hides
+    //    The session name may still be visible as the main pane title, so
+    //    assert on a sidebar-only element (keybind hint "quit") instead of
+    //    the branch name.
     terminal.write('\t');
     await expect(
       terminal.getByText('kirby-session-active', { strict: false })
     ).toBeVisible({ timeout: 10_000 });
-    await expect(
-      terminal.getByText(branchName, { strict: false })
-    ).not.toBeVisible({ timeout: 5_000 });
+    await expect(terminal.getByText('quit', { strict: false })).not.toBeVisible(
+      { timeout: 5_000 }
+    );
 
     // 5. Ctrl+Space exits the terminal pane → sidebar reappears
     //    (Tab is forwarded into the PTY when focused on the agent, so the
     //    exit key is \x00 — see useRawStdinForward.ts)
     terminal.write('\x00');
-    await expect(terminal.getByText(branchName, { strict: false })).toBeVisible(
-      { timeout: 5_000 }
-    );
+    await expect(terminal.getByText('quit', { strict: false })).toBeVisible({
+      timeout: 5_000,
+    });
   });
 });

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -111,6 +111,7 @@
     }
   },
   "dependencies": {
+    "@inkjs/ui": "^2.0.0",
     "@kirby/logger": "*",
     "@kirby/terminal": "*",
     "@kirby/vcs-azure-devops": "*",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -118,6 +118,7 @@
     "@kirby/vcs-core": "*",
     "@kirby/vcs-github": "*",
     "@kirby/worktree-manager": "*",
+    "@mishieck/ink-titled-box": "0.4.2",
     "ink": "^6.8.0",
     "node-pty": "^1.1.0",
     "react": "^19.2.4"

--- a/apps/cli/src/components/AsyncOpsIndicator.tsx
+++ b/apps/cli/src/components/AsyncOpsIndicator.tsx
@@ -2,6 +2,23 @@ import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useAppState } from '../context/AppStateContext.js';
 import { useLayout } from '../context/LayoutContext.js';
+import type { OperationName } from '../hooks/useAsyncOperation.js';
+
+// Human-readable labels for each async operation. Falls back to the
+// raw op name if an entry is missing — keeps us from crashing on a
+// new op that forgot its label.
+const OP_LABELS: Partial<Record<OperationName, string>> = {
+  sync: 'Syncing with origin',
+  rebase: 'Rebasing',
+  'fetch-branches': 'Fetching branches',
+  'create-worktree': 'Creating session',
+  delete: 'Deleting session',
+  'check-delete': 'Checking session',
+  'start-session': 'Starting agent',
+  'open-editor': 'Opening editor',
+  'refresh-pr': 'Refreshing PRs',
+  'post-comment': 'Posting comment',
+};
 
 // Width reservation for the spinner + label. Roughly enough for the
 // longest op name list we expect (e.g. "sync, rebase, fetch-branches").
@@ -32,7 +49,9 @@ export function AsyncOpsIndicator() {
 
   if (asyncOps.inFlight.size === 0) return null;
 
-  const label = [...asyncOps.inFlight].join(', ');
+  const label = [...asyncOps.inFlight]
+    .map((op) => OP_LABELS[op] ?? op)
+    .join(', ');
 
   return (
     <Box

--- a/apps/cli/src/components/AsyncOpsIndicator.tsx
+++ b/apps/cli/src/components/AsyncOpsIndicator.tsx
@@ -1,0 +1,60 @@
+import { Box } from 'ink';
+import { Spinner } from '@inkjs/ui';
+import { useAppState } from '../context/AppStateContext.js';
+import { useLayout } from '../context/LayoutContext.js';
+
+// Width reservation for the spinner + label. Roughly enough for the
+// longest op name list we expect (e.g. "sync, rebase, fetch-branches").
+const INDICATOR_WIDTH = 40;
+// 2-col gutter from the right edge — matches ToastContainer's EDGE_GUTTER
+// so the spinner lines up visually with the toasts below it.
+const EDGE_GUTTER = 2;
+// Row 1 puts the spinner on the pane's title row (inside the top
+// border). Paints to the right of the title text — no overlap in
+// practice because titles are left-aligned and this is right-aligned.
+const TOP_ROW = 1;
+
+// Absolutely-positioned loading indicator in the top-right corner.
+// Shown while any async operations are in flight (`asyncOps.inFlight`
+// is non-empty). The label next to the spinner says what's loading
+// (comma-separated op names).
+//
+// Renders `null` when idle — zero visual weight.
+//
+// Positioning strategy mirrors ToastContainer: full-screen
+// `position="absolute"` wrapper with explicit width/height from
+// LayoutContext, then flex-align inside to push the indicator to the
+// top-right. The inner stack is a column so future additions (e.g. a
+// second indicator row) would stack below the spinner naturally.
+export function AsyncOpsIndicator() {
+  const { asyncOps } = useAppState();
+  const { termCols, termRows } = useLayout();
+
+  if (asyncOps.inFlight.size === 0) return null;
+
+  const label = [...asyncOps.inFlight].join(', ');
+
+  return (
+    <Box
+      position="absolute"
+      // Same as Modal / ToastContainer — Ink types lag the runtime for
+      // offsets. Greppable cast.
+      {...({ top: 0, left: 0 } as object)}
+      width={termCols}
+      height={termRows}
+      alignItems="flex-start"
+      justifyContent="flex-end"
+    >
+      <Box
+        marginTop={TOP_ROW}
+        marginRight={EDGE_GUTTER}
+        width={INDICATOR_WIDTH}
+        // Right-align within the reserved column so the spinner hugs
+        // the right edge even when the label is short.
+        alignItems="flex-end"
+      >
+        <Spinner label={label} />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/components/AsyncOpsIndicator.tsx
+++ b/apps/cli/src/components/AsyncOpsIndicator.tsx
@@ -1,4 +1,4 @@
-import { Box } from 'ink';
+import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useAppState } from '../context/AppStateContext.js';
 import { useLayout } from '../context/LayoutContext.js';
@@ -49,11 +49,16 @@ export function AsyncOpsIndicator() {
         marginTop={TOP_ROW}
         marginRight={EDGE_GUTTER}
         width={INDICATOR_WIDTH}
-        // Right-align within the reserved column so the spinner hugs
-        // the right edge even when the label is short.
-        alignItems="flex-end"
+        // Row flex: main-axis is horizontal, so justifyContent pushes
+        // the label+spinner pair to the right edge of the 40-col
+        // reserved column. Inside the row, label renders first and
+        // the spinner second — so the animated character sits on the
+        // RIGHT of the text.
+        justifyContent="flex-end"
+        gap={1}
       >
-        <Spinner label={label} />
+        <Text>{label}</Text>
+        <Spinner />
       </Box>
     </Box>
   );

--- a/apps/cli/src/components/DeleteConfirmModal.tsx
+++ b/apps/cli/src/components/DeleteConfirmModal.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import { Alert } from '@inkjs/ui';
+import { Modal } from './Modal.js';
+import { Pane } from './Pane.js';
+
+interface DeleteConfirmModalProps {
+  branch: string;
+  reason: string;
+  confirmInput: string;
+}
+
+const CURSOR_BLINK_MS = 500;
+
+// Simple blinking-underscore cursor for the confirm input. Reads more
+// alive than a static "_". Toggled via setInterval; cleared on unmount.
+function BlinkingCursor() {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    const id = setInterval(() => setVisible((v) => !v), CURSOR_BLINK_MS);
+    return () => clearInterval(id);
+  }, []);
+  return <Text dimColor>{visible ? '_' : ' '}</Text>;
+}
+
+// Delete confirmation dialog. Shown when the user triggers a session
+// delete. Input handling lives in handleConfirmDeleteInput (see
+// main-input.ts) — this component is purely visual.
+export function DeleteConfirmModal({
+  branch,
+  reason,
+  confirmInput,
+}: DeleteConfirmModalProps) {
+  return (
+    <Modal>
+      <Pane focused title="Confirm Delete" flexDirection="column">
+        <Box flexDirection="column" padding={1} gap={1}>
+          <Alert variant="warning">{reason}</Alert>
+          <Text>
+            Type{' '}
+            <Text bold color="yellow">
+              {branch}
+            </Text>{' '}
+            to confirm:
+          </Text>
+          <Text>
+            <Text color="cyan">{confirmInput}</Text>
+            <BlinkingCursor />
+          </Text>
+          <Text dimColor>Esc to cancel</Text>
+        </Box>
+      </Pane>
+    </Modal>
+  );
+}

--- a/apps/cli/src/components/Divider.tsx
+++ b/apps/cli/src/components/Divider.tsx
@@ -1,0 +1,43 @@
+import { Text, Box } from 'ink';
+
+interface DividerProps {
+  title?: string;
+  titleColor?: string;
+  dividerColor?: string;
+  padding?: number;
+}
+
+function Fill({ char = '─', color }: { char?: string; color?: string }) {
+  return (
+    <Box flexGrow={1} flexShrink={1} height={1} overflow="hidden">
+      <Text color={color}>{char.repeat(200)}</Text>
+    </Box>
+  );
+}
+
+export function Divider({
+  title,
+  titleColor = 'white',
+  dividerColor = 'gray',
+  padding = 0,
+}: DividerProps) {
+  if (!title) {
+    return (
+      <Box paddingLeft={padding} paddingRight={padding} height={1}>
+        <Fill color={dividerColor} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box paddingLeft={padding} paddingRight={padding} gap={1} height={1}>
+      <Fill color={dividerColor} />
+      <Box flexShrink={0}>
+        <Text color={titleColor} bold>
+          {title}
+        </Text>
+      </Box>
+      <Fill color={dividerColor} />
+    </Box>
+  );
+}

--- a/apps/cli/src/components/Modal.tsx
+++ b/apps/cli/src/components/Modal.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import { Box } from 'ink';
+import { useLayout } from '../context/LayoutContext.js';
+
+interface ModalProps {
+  /** Inner content. Will be centered inside the terminal. */
+  children: ReactNode;
+  /**
+   * Width of the modal's content column. Defaults to 60 columns, which
+   * reads well in most terminals without hugging the edges. Pass a
+   * number or "auto" to let the content size itself.
+   */
+  width?: number | 'auto';
+}
+
+// A reusable modal overlay. Covers the entire terminal viewport and
+// flex-centers its child in the middle of the screen. Designed to be
+// rendered as a sibling of the main layout, NOT nested inside it —
+// typically at the root of the App component (see main.tsx).
+//
+// ── Why this exists ────────────────────────────────────────────────
+// Ink's `position="absolute"` with just the four top/right/bottom/left
+// offsets (to stretch-to-fill) is unreliable in practice. It anchors
+// the element to top-left and ignores the implied dimensions, so
+// `alignItems`/`justifyContent` never get a parent box to center
+// against. Reading the terminal dimensions from LayoutContext and
+// setting explicit `width` + `height` sidesteps the ambiguity —
+// Yoga gets a concrete rectangle to lay out inside.
+//
+// ── Painting ───────────────────────────────────────────────────────
+// We don't set a `backgroundColor`. Ink renders character cells, and
+// when the modal's content paints (border chars, text, padding), it
+// fully overwrites whatever was in those cells before — so there's
+// no transparency to worry about within the modal's footprint. The
+// area outside the modal isn't covered, but that's intended: the
+// underlying app stays visible behind the centered dialog.
+//
+// ── Input layering ─────────────────────────────────────────────────
+// Ink has NO z-index hit-testing — input is routed via `useInput`,
+// not by visual layer. Rendering this overlay does NOT suspend any
+// other `useInput` hooks elsewhere in the tree. The caller MUST
+// ensure that whatever modal opens this also gates other input
+// handlers so only the modal's input fires.
+//
+// In Kirby today this is enforced by MainTab's useInput router (see
+// `screens/main/MainTab.tsx`), which checks `deleteConfirm.confirmDelete`
+// first and routes to `handleConfirmDeleteInput`. Other useInput hooks
+// (DiffPane, raw stdin forwarding, etc.) are gated on pane modes that
+// are mutually exclusive with the delete flow. Future modals must
+// audit and document the same way.
+//
+// Usage:
+//   <Modal>
+//     <Pane focused title="Confirm Delete">...</Pane>
+//   </Modal>
+export function Modal({ children, width = 60 }: ModalProps) {
+  const { termCols, termRows } = useLayout();
+
+  return (
+    <Box
+      position="absolute"
+      // Ink supports these offsets at runtime but the type definitions
+      // lag behind. Spread as an untyped object so the intent stays
+      // greppable and this can be removed when types catch up.
+      {...({ top: 0, left: 0 } as object)}
+      width={termCols}
+      height={termRows}
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box width={width} flexDirection="column">
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/components/Pane.tsx
+++ b/apps/cli/src/components/Pane.tsx
@@ -1,21 +1,29 @@
 import type { ComponentProps, ReactNode } from 'react';
-import { Box, Text } from 'ink';
+import { TitledBox } from '@mishieck/ink-titled-box';
 import { theme } from '../theme.js';
 
-// Pane is a pure visual wrapper: a single Ink <Box> with a round border,
-// an active/inactive color tied to the `focused` prop, and an optional
-// bold title rendered as the first row *inside* the border. It has no
-// hooks, no input handling, no context reads — it just takes props.
+// Pane is a pure visual wrapper: a bordered box with an active/inactive
+// color tied to the `focused` prop and an optional title rendered
+// INSIDE the top border line (e.g. `╭── Title ──╮`). No hooks, no
+// input handling, no context reads — just a styled container.
 //
-// Title placement note: Ink has no native API for rendering text inside
-// a border line (e.g. ╭── Title ──╮). Earlier plan iterations considered
-// disabling borderTop and drawing a custom row, but that's a hack around
-// Ink's supported surface. We use the idiomatic approach: title is a
-// normal first-row child inside the bordered box. Costs 1 row.
+// The border + title rendering is delegated to @mishieck/ink-titled-box,
+// which handles the title-in-border glyph composition for us. Previous
+// iterations tried to do this by hand (custom top row with disabled
+// borderTop + concatenated border chars) — an explicit library does
+// it more reliably than our bespoke implementation.
+//
+// We rely on TitledBox's default title style (space padding on both
+// ends, no decorative wrapper chars) so the title reads as plain text
+// sitting in the border line — keeps the visual quiet.
 
-type BoxProps = ComponentProps<typeof Box>;
+type TitledBoxProps = ComponentProps<typeof TitledBox>;
 
-interface PaneProps extends Omit<BoxProps, 'borderStyle' | 'borderColor'> {
+interface PaneProps
+  extends Omit<
+    TitledBoxProps,
+    'borderStyle' | 'borderColor' | 'titles' | 'titleStyles' | 'children'
+  > {
   focused: boolean;
   title?: string;
   children: ReactNode;
@@ -25,20 +33,14 @@ export function Pane({ focused, title, children, ...boxProps }: PaneProps) {
   const color = focused ? theme.border.active : theme.border.inactive;
 
   return (
-    <Box
+    <TitledBox
       borderStyle={theme.border.style}
       borderColor={color}
+      titles={title ? [title] : []}
       flexDirection="column"
       {...boxProps}
     >
-      {title && (
-        <Box flexShrink={0}>
-          <Text bold color={color}>
-            {title}
-          </Text>
-        </Box>
-      )}
       {children}
-    </Box>
+    </TitledBox>
   );
 }

--- a/apps/cli/src/components/Pane.tsx
+++ b/apps/cli/src/components/Pane.tsx
@@ -1,0 +1,44 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../theme.js';
+
+// Pane is a pure visual wrapper: a single Ink <Box> with a round border,
+// an active/inactive color tied to the `focused` prop, and an optional
+// bold title rendered as the first row *inside* the border. It has no
+// hooks, no input handling, no context reads — it just takes props.
+//
+// Title placement note: Ink has no native API for rendering text inside
+// a border line (e.g. ╭── Title ──╮). Earlier plan iterations considered
+// disabling borderTop and drawing a custom row, but that's a hack around
+// Ink's supported surface. We use the idiomatic approach: title is a
+// normal first-row child inside the bordered box. Costs 1 row.
+
+type BoxProps = ComponentProps<typeof Box>;
+
+interface PaneProps extends Omit<BoxProps, 'borderStyle' | 'borderColor'> {
+  focused: boolean;
+  title?: string;
+  children: ReactNode;
+}
+
+export function Pane({ focused, title, children, ...boxProps }: PaneProps) {
+  const color = focused ? theme.border.active : theme.border.inactive;
+
+  return (
+    <Box
+      borderStyle={theme.border.style}
+      borderColor={color}
+      flexDirection="column"
+      {...boxProps}
+    >
+      {title && (
+        <Box flexShrink={0}>
+          <Text bold color={color}>
+            {title}
+          </Text>
+        </Box>
+      )}
+      {children}
+    </Box>
+  );
+}

--- a/apps/cli/src/components/Sidebar.tsx
+++ b/apps/cli/src/components/Sidebar.tsx
@@ -1,18 +1,25 @@
 import { memo, useMemo } from 'react';
 import { Text, Box } from 'ink';
+import { Divider } from './Divider.js';
 import type { PullRequestInfo } from '@kirby/vcs-core';
 import type { AgentSession, SidebarItem } from '../types.js';
 import { PrBadge } from './PrBadge.js';
 import { SidebarLayout } from './SidebarLayout.js';
-import { truncate } from '../utils/truncate.js';
 import { computeScrollWindow } from '../utils/scroll-window.js';
 import { useConfig } from '../context/ConfigContext.js';
 import { useKeybinds } from '../context/KeybindContext.js';
+import { LAYOUT } from '../context/LayoutContext.js';
 
 // ── Constants ───────────────────────────────────────────────────
 
-// Header: 1 line of text + 1 marginBottom = 2 lines
-const HEADER_LINES = 2;
+// Rows the sidebar does NOT get for scrollable items:
+//   - Pane border (top + bottom)       → LAYOUT.PANE_BORDER_ROWS
+//   - Pane title row ("Kirby")         → LAYOUT.PANE_TITLE_ROWS
+//   - Bottom status bar at the root    → LAYOUT.BOTTOM_STATUS_ROWS
+// This compensates for the fact that Sidebar gets `termRows` (the full
+// terminal height) but actually renders inside a smaller flex slot.
+const SIDEBAR_CHROME_ROWS =
+  LAYOUT.PANE_BORDER_ROWS + LAYOUT.PANE_TITLE_ROWS + LAYOUT.BOTTOM_STATUS_ROWS;
 const LEGEND_LINES = 2; // "passed/failed/pending" + "needs attention/approved"
 
 // ── Section header detection ────────────────────────────────────
@@ -58,17 +65,24 @@ const SessionItemRow = memo(function SessionItemRow({
   conflictCount: number | undefined;
   vcsConfigured: boolean;
 }) {
-  const icon = session.running ? '●' : '○';
-  const color = session.running ? 'green' : 'gray';
+  // Single icon column: selected state (◉ ring) overrides, otherwise
+  // running state (● filled green / ○ hollow gray). Saves 2 chars vs.
+  // the old "› " + "● " two-column layout.
+  let icon: string;
+  let iconColor: string;
+  if (selected) {
+    icon = session.running ? '◉' : '◎';
+    iconColor = 'cyan';
+  } else {
+    icon = session.running ? '●' : '○';
+    iconColor = session.running ? 'green' : 'gray';
+  }
 
   return (
     <Box flexDirection="column">
-      <Text>
-        <Text color={selected ? 'cyan' : undefined}>
-          {selected ? '› ' : '  '}
-        </Text>
-        <Text color={color}>{icon} </Text>
-        <Text bold={selected}>{truncate(pr?.title || session.name, 42)}</Text>
+      <Text wrap="truncate">
+        <Text color={iconColor}>{icon} </Text>
+        <Text bold={selected}>{pr?.title || session.name}</Text>
         {isMerged ? (
           <Text dimColor color="green">
             {' '}
@@ -78,7 +92,7 @@ const SessionItemRow = memo(function SessionItemRow({
       </Text>
       {conflictCount != null && conflictCount > 0 ? (
         <Text dimColor color="yellow">
-          {'    '}
+          {'  '}
           {conflictCount} conflict{conflictCount !== 1 ? 's' : ''}
         </Text>
       ) : null}
@@ -98,18 +112,24 @@ const OrphanPrRow = memo(function OrphanPrRow({
   sidebarWidth: number;
   running?: boolean;
 }) {
+  let icon: string;
+  let iconColor: string;
+  if (selected) {
+    icon = running ? '◉' : '◎';
+    iconColor = 'cyan';
+  } else if (running != null) {
+    icon = running ? '●' : '○';
+    iconColor = running ? 'green' : 'gray';
+  } else {
+    icon = '○';
+    iconColor = 'gray';
+  }
+
   return (
     <Box flexDirection="column">
-      <Text>
-        <Text color={selected ? 'cyan' : undefined}>
-          {selected ? '› ' : '  '}
-        </Text>
-        {running != null && (
-          <Text color={running ? 'green' : 'gray'}>
-            {running ? '● ' : '○ '}
-          </Text>
-        )}
-        <Text bold={selected}>{truncate(pr.title || pr.sourceBranch, 42)}</Text>
+      <Text wrap="truncate">
+        <Text color={iconColor}>{icon} </Text>
+        <Text bold={selected}>{pr.title || pr.sourceBranch}</Text>
       </Text>
       <PrBadge pr={pr} sidebarWidth={sidebarWidth} />
     </Box>
@@ -120,30 +140,31 @@ const ReviewPrRow = memo(function ReviewPrRow({
   pr,
   selected,
   sidebarWidth,
-  innerWidth,
   running,
 }: {
   pr: PullRequestInfo;
   selected: boolean;
   sidebarWidth: number;
-  innerWidth: number;
   running?: boolean;
 }) {
-  const ledWidth = running != null ? 2 : 0;
+  let icon: string;
+  let iconColor: string;
+  if (selected) {
+    icon = running ? '◉' : '◎';
+    iconColor = 'cyan';
+  } else if (running != null) {
+    icon = running ? '●' : '○';
+    iconColor = running ? 'green' : 'gray';
+  } else {
+    icon = '○';
+    iconColor = 'gray';
+  }
+
   return (
     <Box flexDirection="column">
-      <Text>
-        <Text color={selected ? 'cyan' : undefined}>
-          {selected ? '› ' : '  '}
-        </Text>
-        {running != null && (
-          <Text color={running ? 'green' : 'gray'}>
-            {running ? '● ' : '○ '}
-          </Text>
-        )}
-        <Text bold={selected}>
-          {truncate(pr.title || pr.sourceBranch, innerWidth - 4 - ledWidth)}
-        </Text>
+      <Text wrap="truncate">
+        <Text color={iconColor}>{icon} </Text>
+        <Text bold={selected}>{pr.title || pr.sourceBranch}</Text>
       </Text>
       <PrBadge
         pr={pr}
@@ -158,21 +179,20 @@ function SectionHeader({
   title,
   color,
   count,
-  innerWidth,
   first,
 }: {
   title: string;
   color: string;
   count: number;
-  innerWidth: number;
   first: boolean;
 }) {
   return (
-    <Box flexDirection="column" marginTop={first ? 0 : 1}>
-      <Text bold color={color}>
-        {title} ({count})
-      </Text>
-      <Text dimColor>{'─'.repeat(Math.max(1, innerWidth))}</Text>
+    <Box marginTop={first ? 0 : 1}>
+      <Divider
+        title={`${title} (${count})`}
+        titleColor={color}
+        dividerColor="gray"
+      />
     </Box>
   );
 }
@@ -197,7 +217,6 @@ export const Sidebar = memo(function Sidebar({
 }: SidebarProps) {
   const { vcsConfigured } = useConfig();
   const keybinds = useKeybinds();
-  const innerWidth = Math.max(10, sidebarWidth - 2);
 
   // Build dynamic keybind hints from the active preset
   const sidebarHints = useMemo(() => {
@@ -263,7 +282,7 @@ export const Sidebar = memo(function Sidebar({
   // Compute height of each row based on its content
   const rowHeights = useMemo(() => {
     return rows.map((row): number => {
-      if (row.type === 'header') return row.first ? 2 : 3; // title + separator (+ marginTop if not first)
+      if (row.type === 'header') return row.first ? 1 : 2; // divider (+ marginTop if not first)
       const { item } = row;
       if (item.kind === 'session') {
         let h = 1; // title line
@@ -278,9 +297,9 @@ export const Sidebar = memo(function Sidebar({
 
   // Compute scroll window using actual row heights
   const { fullyVisibleRows, gap, aboveCount, belowCount } = useMemo(() => {
-    // Total non-item lines: header + keybinds margin + keybind lines + optional legend
+    // Total non-item lines: sidebar chrome + keybinds margin + keybind lines + optional legend
     const chromeLines =
-      HEADER_LINES +
+      SIDEBAR_CHROME_ROWS +
       1 +
       keybindLineCount +
       (vcsConfigured ? 1 + LEGEND_LINES : 0);
@@ -363,7 +382,6 @@ export const Sidebar = memo(function Sidebar({
           title={label.title}
           color={label.color}
           count={row.count}
-          innerWidth={innerWidth}
           first={row.first}
         />
       );
@@ -402,7 +420,6 @@ export const Sidebar = memo(function Sidebar({
         pr={item.pr}
         selected={selected}
         sidebarWidth={sidebarWidth}
-        innerWidth={innerWidth}
         running={item.running}
       />
     );
@@ -410,6 +427,7 @@ export const Sidebar = memo(function Sidebar({
 
   return (
     <SidebarLayout
+      title="😸 Kirby"
       focused={focused}
       sidebarWidth={sidebarWidth}
       emptyText="(no sessions)"

--- a/apps/cli/src/components/SidebarLayout.tsx
+++ b/apps/cli/src/components/SidebarLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { Text, Box } from 'ink';
+import { Pane } from './Pane.js';
 
 interface SidebarLayoutProps {
   title?: string;
@@ -12,6 +13,12 @@ interface SidebarLayoutProps {
   children: ReactNode;
 }
 
+// Layout wrapper for the sidebar column. Content is laid out top-to-bottom:
+//   - optional title (rendered by Pane as the first row inside the border)
+//   - scrollable items area (flex-grows to fill remaining space)
+//   - keybinds footer
+//   - optional legend
+// The Pane component owns the round border and the focused/unfocused color.
 export function SidebarLayout({
   title,
   focused,
@@ -23,18 +30,8 @@ export function SidebarLayout({
   children,
 }: SidebarLayoutProps) {
   return (
-    <Box
-      flexDirection="column"
-      width={sidebarWidth}
-      flexShrink={0}
-      paddingX={1}
-    >
+    <Pane focused={focused} title={title} width={sidebarWidth} flexShrink={0}>
       <Box flexDirection="column" flexGrow={1}>
-        {title && (
-          <Text bold color={focused ? 'blue' : 'gray'}>
-            {title}
-          </Text>
-        )}
         {isEmpty ? <Text dimColor>{emptyText}</Text> : children}
       </Box>
       <Box marginTop={1} flexDirection="column">
@@ -45,6 +42,6 @@ export function SidebarLayout({
           {legend}
         </Box>
       )}
-    </Box>
+    </Pane>
   );
 }

--- a/apps/cli/src/components/StatusBar.tsx
+++ b/apps/cli/src/components/StatusBar.tsx
@@ -1,33 +1,22 @@
 import { Text } from 'ink';
-import { Alert, Spinner } from '@inkjs/ui';
-import { useAppState } from '../context/AppStateContext.js';
-import { useSessionData } from '../context/SessionContext.js';
 import { useConfig } from '../context/ConfigContext.js';
 
-// Slim bottom status bar — one row.
+// Bottom bar. After M7 this is the quietest surface in the app —
+// everything transient moved elsewhere:
 //
-// Only shows persistent/ongoing state. Transient notifications (the old
-// `statusMessage` flow) now render as toasts in the top-right — see
-// ToastContainer + ToastContext. Delete confirm UI lives in
-// DeleteConfirmModal. Branch picker filter lives in its own pane.
+//   - PR fetch errors              → toast (SessionContext useEffect)
+//   - statusMessage (transient)    → toast (flashStatus → ToastContext)
+//   - asyncOps.inFlight spinner    → AsyncOpsIndicator overlay (top-right)
+//   - ctrl+space-to-exit hint      → pane title (getPaneTitle)
+//   - delete confirmation          → DeleteConfirmModal
+//   - branch picker filter echo    → BranchPicker pane itself
 //
-// Priority (highest first):
-//   1. prError        → persistent, red, until next successful poll
-//   2. terminal focus → dim hint
-//   3. asyncOps       → live spinner
-//   4. VCS setup hint → dim hint when not configured
+// Only the VCS setup hint remains here. Renders null once VCS is
+// configured, so the bottom row is completely empty in the steady
+// state. If we never find another use for this strip, a follow-up can
+// delete StatusBar entirely and surface the hint as an onboarding toast.
 export function StatusBar() {
-  const { nav, asyncOps } = useAppState();
-  const { prError } = useSessionData();
   const { vcsConfigured } = useConfig();
-
-  if (prError) return <Alert variant="error">{`PR error: ${prError}`}</Alert>;
-  if (nav.focus === 'terminal')
-    return <Text dimColor>ctrl+space to exit terminal</Text>;
-
-  if (asyncOps.inFlight.size > 0) {
-    return <Spinner label={[...asyncOps.inFlight].join(', ')} />;
-  }
-
-  return !vcsConfigured ? <Text dimColor>(s to configure VCS)</Text> : null;
+  if (vcsConfigured) return null;
+  return <Text dimColor>(s to configure VCS)</Text>;
 }

--- a/apps/cli/src/components/StatusBar.tsx
+++ b/apps/cli/src/components/StatusBar.tsx
@@ -1,61 +1,33 @@
 import { Text } from 'ink';
+import { Alert, Spinner } from '@inkjs/ui';
 import { useAppState } from '../context/AppStateContext.js';
-import {
-  useSessionActions,
-  useSessionData,
-} from '../context/SessionContext.js';
+import { useSessionData } from '../context/SessionContext.js';
 import { useConfig } from '../context/ConfigContext.js';
 
+// Slim bottom status bar — one row.
+//
+// Only shows persistent/ongoing state. Transient notifications (the old
+// `statusMessage` flow) now render as toasts in the top-right — see
+// ToastContainer + ToastContext. Delete confirm UI lives in
+// DeleteConfirmModal. Branch picker filter lives in its own pane.
+//
+// Priority (highest first):
+//   1. prError        → persistent, red, until next successful poll
+//   2. terminal focus → dim hint
+//   3. asyncOps       → live spinner
+//   4. VCS setup hint → dim hint when not configured
 export function StatusBar() {
-  const { nav, branchPicker, deleteConfirm, asyncOps } = useAppState();
-  const { statusMessage } = useSessionActions();
+  const { nav, asyncOps } = useAppState();
   const { prError } = useSessionData();
   const { vcsConfigured } = useConfig();
 
-  if (deleteConfirm.confirmDelete) {
-    return (
-      <Text>
-        <Text color="red">
-          Warning: {deleteConfirm.confirmDelete.reason}. Type{' '}
-        </Text>
-        <Text bold color="yellow">
-          {deleteConfirm.confirmDelete.branch}
-        </Text>
-        <Text color="red"> to confirm: </Text>
-        <Text color="cyan">{deleteConfirm.confirmInput}</Text>
-        <Text dimColor>_</Text>
-        <Text dimColor> · Esc cancel</Text>
-      </Text>
-    );
-  }
-  if (branchPicker.creating) {
-    return (
-      <Text>
-        Branch: <Text color="cyan">{branchPicker.branchFilter}</Text>
-        <Text dimColor>_</Text>
-        <Text dimColor> · Enter select · Esc cancel</Text>
-      </Text>
-    );
-  }
-  if (statusMessage) {
-    return <Text color="yellow">{statusMessage}</Text>;
-  }
-  if (prError) {
-    return <Text color="red">PR error: {prError}</Text>;
-  }
-  if (nav.focus === 'terminal') {
+  if (prError) return <Alert variant="error">{`PR error: ${prError}`}</Alert>;
+  if (nav.focus === 'terminal')
     return <Text dimColor>ctrl+space to exit terminal</Text>;
+
+  if (asyncOps.inFlight.size > 0) {
+    return <Spinner label={[...asyncOps.inFlight].join(', ')} />;
   }
 
-  const ops =
-    asyncOps.inFlight.size > 0
-      ? ` · ${[...asyncOps.inFlight].join(', ')}...`
-      : '';
-
-  return (
-    <Text dimColor>
-      {!vcsConfigured ? ' · (s to configure VCS)' : ''}
-      {ops ? <Text color="yellow">{ops}</Text> : null}
-    </Text>
-  );
+  return !vcsConfigured ? <Text dimColor>(s to configure VCS)</Text> : null;
 }

--- a/apps/cli/src/components/StatusBar.tsx
+++ b/apps/cli/src/components/StatusBar.tsx
@@ -7,7 +7,7 @@ import {
 import { useConfig } from '../context/ConfigContext.js';
 
 export function StatusBar() {
-  const { branchPicker, deleteConfirm, asyncOps } = useAppState();
+  const { nav, branchPicker, deleteConfirm, asyncOps } = useAppState();
   const { statusMessage } = useSessionActions();
   const { prError } = useSessionData();
   const { vcsConfigured } = useConfig();
@@ -42,6 +42,9 @@ export function StatusBar() {
   }
   if (prError) {
     return <Text color="red">PR error: {prError}</Text>;
+  }
+  if (nav.focus === 'terminal') {
+    return <Text dimColor>ctrl+space to exit terminal</Text>;
   }
 
   const ops =

--- a/apps/cli/src/components/TerminalView.tsx
+++ b/apps/cli/src/components/TerminalView.tsx
@@ -3,18 +3,11 @@ import { Text, Box } from 'ink';
 
 export const TerminalView = memo(function TerminalView({
   content,
-  focused,
 }: {
   content: string;
-  focused: boolean;
 }) {
   return (
-    <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
-      <Text bold color={focused ? 'green' : 'gray'}>
-        🤖 Agent
-        {focused ? <Text color="green"> (ctrl+space to exit)</Text> : null}
-      </Text>
-      <Text dimColor>{'─'.repeat(40)}</Text>
+    <Box flexDirection="column" flexGrow={1} overflow="hidden">
       <Text wrap="truncate">{content}</Text>
     </Box>
   );

--- a/apps/cli/src/components/ToastContainer.tsx
+++ b/apps/cli/src/components/ToastContainer.tsx
@@ -1,0 +1,98 @@
+import { Box } from 'ink';
+import { Alert } from '@inkjs/ui';
+import { useToastState } from '../context/ToastContext.js';
+import { useLayout } from '../context/LayoutContext.js';
+
+// Width of the toast column — toasts align to one side inside it, so
+// long messages fill out the full 40 cols and short ones hug the edge.
+const TOAST_WIDTH = 40;
+// Gutter between the toast stack and the nearest terminal edges.
+const EDGE_GUTTER = 2;
+
+export type ToastPosition =
+  | 'top-right'
+  | 'top-left'
+  | 'bottom-right'
+  | 'bottom-left';
+
+interface ToastContainerProps {
+  position?: ToastPosition;
+}
+
+// Outer wrapper anchors. The wrapper is a row flex (Ink's default
+// flexDirection), so `alignItems` controls VERTICAL placement
+// (cross-axis) and `justifyContent` controls HORIZONTAL placement
+// (main-axis). The inner stack is a column flex — its alignItems
+// switches axes (cross becomes horizontal). Don't confuse the two.
+const ANCHOR: Record<
+  ToastPosition,
+  {
+    alignItems: 'flex-start' | 'flex-end';
+    justifyContent: 'flex-start' | 'flex-end';
+  }
+> = {
+  'top-right': { alignItems: 'flex-start', justifyContent: 'flex-end' },
+  'top-left': { alignItems: 'flex-start', justifyContent: 'flex-start' },
+  'bottom-right': { alignItems: 'flex-end', justifyContent: 'flex-end' },
+  'bottom-left': { alignItems: 'flex-end', justifyContent: 'flex-start' },
+};
+
+// Floating toast stack. Renders nothing when there are no toasts, so
+// it adds zero visual weight in the common case.
+//
+// ── Positioning strategy ───────────────────────────────────────────
+// A full-screen `position="absolute"` wrapper anchored at top-left
+// with explicit `width`/`height` from LayoutContext, then flex-align
+// inside it to push the inner stack into the chosen corner. This is
+// the same pattern Modal uses. We can't use `top`/`right` offsets
+// directly to push an element into a corner — Ink's runtime accepts
+// them but non-zero values don't reliably apply.
+//
+// ── Input layering ─────────────────────────────────────────────────
+// Toasts don't capture input — they're non-interactive. So this
+// component doesn't need to coordinate with any `useInput` hooks.
+// (Modals are different — see Modal.tsx for the input-layering note.)
+export function ToastContainer({
+  position = 'top-right',
+}: ToastContainerProps = {}) {
+  const { toasts } = useToastState();
+  const { termCols, termRows } = useLayout();
+
+  if (toasts.length === 0) return null;
+
+  const anchor = ANCHOR[position];
+  const isTop = position === 'top-right' || position === 'top-left';
+  const isRight = position === 'top-right' || position === 'bottom-right';
+
+  return (
+    <Box
+      position="absolute"
+      // Ink supports this offset; types lag. Same greppable cast as Modal.
+      {...({ top: 0, left: 0 } as object)}
+      width={termCols}
+      height={termRows}
+      alignItems={anchor.alignItems}
+      justifyContent={anchor.justifyContent}
+    >
+      <Box
+        flexDirection="column"
+        gap={1}
+        marginTop={isTop ? EDGE_GUTTER : 0}
+        marginBottom={isTop ? 0 : EDGE_GUTTER}
+        marginLeft={isRight ? 0 : EDGE_GUTTER}
+        marginRight={isRight ? EDGE_GUTTER : 0}
+        width={TOAST_WIDTH}
+        // `alignItems` on a column flex controls the cross-axis
+        // (horizontal) — this right- or left-aligns each toast inside
+        // the 40-col stack so short messages don't float awkwardly.
+        alignItems={isRight ? 'flex-end' : 'flex-start'}
+      >
+        {toasts.map((t) => (
+          <Alert key={t.id} variant={t.variant}>
+            {t.message}
+          </Alert>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/context/LayoutContext.tsx
+++ b/apps/cli/src/context/LayoutContext.tsx
@@ -12,9 +12,13 @@ import { useTerminalDimensions } from '../hooks/useTerminalDimensions.js';
 // so downstream consumers don't need to do any more math.
 const SIDEBAR_WIDTH = 48;
 const BOTTOM_STATUS_ROWS = 1; // slim status row at the bottom of the screen
-const PANE_BORDER_ROWS = 2; // round-border top + bottom
-const PANE_TITLE_ROWS = 1; // first-row bold title inside the bordered Box
-const PANE_BORDER_COLS = 2; // round-border left + right
+const PANE_BORDER_ROWS = 2; // top + bottom border
+// Titles live INSIDE the top border line (via @mishieck/ink-titled-box),
+// so they don't consume a dedicated content row. Kept as a named
+// constant for clarity — flip to >0 if we ever switch back to an
+// above-content title.
+const PANE_TITLE_ROWS = 0;
+const PANE_BORDER_COLS = 2; // left + right border
 
 export const LAYOUT = {
   SIDEBAR_WIDTH,

--- a/apps/cli/src/context/LayoutContext.tsx
+++ b/apps/cli/src/context/LayoutContext.tsx
@@ -2,7 +2,27 @@ import { createContext, useContext, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { useTerminalDimensions } from '../hooks/useTerminalDimensions.js';
 
+// Layout constants. Exported as LAYOUT so any consumer that needs to
+// recompute pane dimensions (e.g. MainTab's auto-hide sidebar override)
+// reuses the same numbers instead of hardcoding its own.
+//
+// paneCols/paneRows below are the *interior* dimensions of the main
+// pane — what the PTY and DiffViewer actually draw into. The pane
+// border (2 cols + 2 rows) and title row (1 row) are already subtracted,
+// so downstream consumers don't need to do any more math.
 const SIDEBAR_WIDTH = 48;
+const BOTTOM_STATUS_ROWS = 1; // slim status row at the bottom of the screen
+const PANE_BORDER_ROWS = 2; // round-border top + bottom
+const PANE_TITLE_ROWS = 1; // first-row bold title inside the bordered Box
+const PANE_BORDER_COLS = 2; // round-border left + right
+
+export const LAYOUT = {
+  SIDEBAR_WIDTH,
+  BOTTOM_STATUS_ROWS,
+  PANE_BORDER_ROWS,
+  PANE_TITLE_ROWS,
+  PANE_BORDER_COLS,
+} as const;
 
 export interface TerminalLayout {
   paneCols: number;
@@ -21,8 +41,11 @@ const LayoutContext = createContext<LayoutContextValue | null>(null);
 export function LayoutProvider({ children }: { children: ReactNode }) {
   const { rows: termRows, cols: termCols } = useTerminalDimensions();
 
-  const paneCols = Math.max(20, termCols - SIDEBAR_WIDTH - 2);
-  const paneRows = Math.max(5, termRows - 5);
+  const paneCols = Math.max(20, termCols - SIDEBAR_WIDTH - PANE_BORDER_COLS);
+  const paneRows = Math.max(
+    5,
+    termRows - BOTTOM_STATUS_ROWS - PANE_BORDER_ROWS - PANE_TITLE_ROWS
+  );
 
   const terminal = useMemo(
     () => ({ paneCols, paneRows }),

--- a/apps/cli/src/context/SessionContext.tsx
+++ b/apps/cli/src/context/SessionContext.tsx
@@ -17,6 +17,8 @@ import { useMergedBranches } from '../hooks/useMergedBranches.js';
 import { useConflictCounts } from '../hooks/useConflictCounts.js';
 import { useConfig } from './ConfigContext.js';
 import { useAppState } from './AppStateContext.js';
+import { useToastActions } from './ToastContext.js';
+import type { ToastVariant } from './ToastContext.js';
 import type { AgentSession } from '../types.js';
 import { sortSessionsByPrId } from '../utils/session-sort.js';
 
@@ -41,8 +43,12 @@ export interface SessionDataContextValue {
 // ── Actions context (consumed by input handlers / StatusBar) ──
 
 export interface SessionActionsContextValue {
-  statusMessage: string | null;
-  flashStatus: (msg: string) => void;
+  /**
+   * Push a transient notification toast. Defaults to the `info` variant.
+   * Internally delegates to ToastContext — every call renders in the
+   * top-right toast stack.
+   */
+  flashStatus: (msg: string, variant?: ToastVariant) => void;
   refreshSessions: () => Promise<AgentSession[]>;
   performDelete: (sessionName: string, branch: string) => Promise<void>;
   refreshPr: () => void;
@@ -57,6 +63,7 @@ const SessionActionsContext = createContext<SessionActionsContextValue | null>(
 export function SessionProvider({ children }: { children: ReactNode }) {
   const { config, provider, providers, setConfig } = useConfig();
   const { branchPicker } = useAppState();
+  const { flash } = useToastActions();
 
   const sessionMgr = useSessionManager(
     providers,
@@ -70,9 +77,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const onMergedDelete = useCallback(
     (sessionName: string, branch: string) => {
       sessionMgr.performDelete(sessionName, branch);
-      sessionMgr.flashStatus(`Auto-deleted merged branch: ${branch}`);
+      flash(`Auto-deleted merged branch: ${branch}`, 'success');
     },
-    [sessionMgr]
+    [sessionMgr, flash]
   );
 
   const { mergedBranches } = useMergedBranches(
@@ -143,26 +150,17 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     ]
   );
 
-  const { statusMessage, flashStatus, refreshSessions, performDelete } =
-    sessionMgr;
+  const { refreshSessions, performDelete } = sessionMgr;
 
   const actionsValue = useMemo<SessionActionsContextValue>(
     () => ({
-      statusMessage,
-      flashStatus,
+      flashStatus: flash,
       refreshSessions,
       performDelete,
       refreshPr,
       triggerSync,
     }),
-    [
-      statusMessage,
-      flashStatus,
-      refreshSessions,
-      performDelete,
-      refreshPr,
-      triggerSync,
-    ]
+    [flash, refreshSessions, performDelete, refreshPr, triggerSync]
   );
 
   return (

--- a/apps/cli/src/context/SessionContext.tsx
+++ b/apps/cli/src/context/SessionContext.tsx
@@ -57,8 +57,8 @@ export interface SessionActionsContextValue {
   flashStatus: (msg: string, variant?: ToastVariant) => void;
   refreshSessions: () => Promise<AgentSession[]>;
   performDelete: (sessionName: string, branch: string) => Promise<void>;
-  refreshPr: () => void;
-  triggerSync: () => void;
+  refreshPr: () => Promise<void>;
+  triggerSync: () => Promise<void>;
 }
 
 const SessionDataContext = createContext<SessionDataContextValue | null>(null);

--- a/apps/cli/src/context/SessionContext.tsx
+++ b/apps/cli/src/context/SessionContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useMemo, useCallback } from 'react';
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useCallback,
+  useEffect,
+} from 'react';
 import type { ReactNode } from 'react';
 import type {
   PullRequestInfo,
@@ -73,6 +79,16 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
   const { prMap, error: prError, refresh: refreshPr } = usePrData();
   const { lastSynced, triggerSync } = useRemoteSync();
+
+  // Surface PR fetch errors as transient toasts instead of a persistent
+  // bottom-bar alert. `usePrData` re-sets the same error string on every
+  // failed poll; React's setState bails on Object.is equality, so this
+  // effect only fires when the ERROR VALUE CHANGES — not on every poll.
+  // Null → non-null fires once; non-null → different non-null fires once;
+  // non-null → null is silent (error resolved).
+  useEffect(() => {
+    if (prError) flash(`PR error: ${prError}`, 'error');
+  }, [prError, flash]);
 
   const onMergedDelete = useCallback(
     (sessionName: string, branch: string) => {

--- a/apps/cli/src/context/ToastContext.tsx
+++ b/apps/cli/src/context/ToastContext.tsx
@@ -1,0 +1,155 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { ReactNode } from 'react';
+
+// Transient notifications — stacked in a corner, auto-dismissing.
+//
+// Lives in its own context so it's reusable anywhere (input handlers,
+// async error paths, demo helpers) without taking a session/config
+// dependency.
+//
+// ── Two-context split ──────────────────────────────────────────────
+// We expose `useToastState()` and `useToastActions()` separately so
+// the dozens of consumers that only push toasts (`flash`) don't get
+// re-rendered every time the queue changes. Only the renderer
+// (`ToastContainer`) needs the queue itself; everyone else only
+// needs stable action references.
+//
+// ── Timer ownership ────────────────────────────────────────────────
+// Every toast owns its own dismissal timeout. Handles are tracked in
+// a Map ref and cleared on dismiss, eviction, and provider unmount —
+// guaranteeing no stray callbacks fire against unmounted components
+// or evicted ids.
+
+export type ToastVariant = 'info' | 'success' | 'warning' | 'error';
+
+export interface Toast {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+export interface ToastStateValue {
+  toasts: Toast[];
+}
+
+export interface ToastActionsValue {
+  flash: (message: string, variant?: ToastVariant) => void;
+  dismiss: (id: string) => void;
+}
+
+const TOAST_DURATION_MS = 3000;
+const MAX_VISIBLE_TOASTS = 5;
+
+const ToastStateContext = createContext<ToastStateValue | null>(null);
+const ToastActionsContext = createContext<ToastActionsValue | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  // Monotonic id counter — unique for the provider's lifetime.
+  // Combined with timer cleanup below there's no risk of stale
+  // setTimeout callbacks dismissing the wrong toast, so we don't need
+  // to mix in Date.now() like an earlier draft did.
+  const nextIdRef = useRef(0);
+  // Active dismissal timers, keyed by toast id. Cleared on dismiss,
+  // eviction (when the 5-cap drops the oldest), and provider unmount.
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map()
+  );
+
+  // Cleanup all pending timers on unmount.
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const handle of timers.values()) clearTimeout(handle);
+      timers.clear();
+    };
+  }, []);
+
+  const clearTimer = useCallback((id: string) => {
+    const handle = timersRef.current.get(id);
+    if (handle) {
+      clearTimeout(handle);
+      timersRef.current.delete(id);
+    }
+  }, []);
+
+  const dismiss = useCallback(
+    (id: string) => {
+      clearTimer(id);
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    },
+    [clearTimer]
+  );
+
+  const flash = useCallback(
+    (message: string, variant: ToastVariant = 'info') => {
+      const id = String(nextIdRef.current++);
+      setToasts((prev) => {
+        const next = [...prev, { id, message, variant }];
+        if (next.length <= MAX_VISIBLE_TOASTS) return next;
+        // Overflow — clear timers for the toasts being evicted so they
+        // don't later fire dismiss against ids that no longer exist.
+        const overflowCount = next.length - MAX_VISIBLE_TOASTS;
+        for (let i = 0; i < overflowCount; i++) {
+          clearTimer(next[i]!.id);
+        }
+        return next.slice(overflowCount);
+      });
+      const handle = setTimeout(() => dismiss(id), TOAST_DURATION_MS);
+      timersRef.current.set(id, handle);
+    },
+    [clearTimer, dismiss]
+  );
+
+  // State context: changes when the queue changes. ToastContainer is
+  // the only intended consumer.
+  const stateValue = useMemo<ToastStateValue>(() => ({ toasts }), [toasts]);
+
+  // Actions context: object reference is stable across queue updates
+  // (flash/dismiss are themselves stable callbacks). Consumers won't
+  // re-render on toast add/remove.
+  const actionsValue = useMemo<ToastActionsValue>(
+    () => ({ flash, dismiss }),
+    [flash, dismiss]
+  );
+
+  return (
+    <ToastStateContext.Provider value={stateValue}>
+      <ToastActionsContext.Provider value={actionsValue}>
+        {children}
+      </ToastActionsContext.Provider>
+    </ToastStateContext.Provider>
+  );
+}
+
+/**
+ * Read the toast queue. Use only in components that render toasts
+ * (typically just `ToastContainer`). Re-renders on every add/remove.
+ */
+export function useToastState(): ToastStateValue {
+  const ctx = useContext(ToastStateContext);
+  if (!ctx)
+    throw new Error('useToastState must be used within a ToastProvider');
+  return ctx;
+}
+
+/**
+ * Read the toast actions (`flash`, `dismiss`). Stable across queue
+ * updates — pushing a toast won't re-render the caller. Use this from
+ * input handlers, async paths, anywhere you need to flash but don't
+ * need to render the queue.
+ */
+export function useToastActions(): ToastActionsValue {
+  const ctx = useContext(ToastActionsContext);
+  if (!ctx)
+    throw new Error('useToastActions must be used within a ToastProvider');
+  return ctx;
+}

--- a/apps/cli/src/hooks/useAsyncOperation.ts
+++ b/apps/cli/src/hooks/useAsyncOperation.ts
@@ -8,7 +8,9 @@ export type OperationName =
   | 'delete'
   | 'check-delete'
   | 'start-session'
-  | 'open-editor';
+  | 'open-editor'
+  | 'refresh-pr'
+  | 'post-comment';
 
 export function useAsyncOperation() {
   const [inFlight, setInFlight] = useState<Set<OperationName>>(new Set());

--- a/apps/cli/src/hooks/usePrData.ts
+++ b/apps/cli/src/hooks/usePrData.ts
@@ -11,33 +11,33 @@ export function usePrData(refreshInterval = 60000) {
   const [error, setError] = useState<string | null>(null);
   const mountedRef = useRef(true);
 
-  const refresh = useCallback(() => {
+  const refresh = useCallback(async (): Promise<void> => {
     if (!provider || !provider.isConfigured(vendorAuth, vendorProject)) return;
     setLoading(true);
-    provider
-      .fetchPullRequests(vendorAuth, vendorProject)
-      .then((map) => {
-        if (mountedRef.current) {
-          setPrMap(map);
-          setError(null);
-        }
-      })
-      .catch((err: Error) => {
-        logError(`fetchPullRequests [${provider.id}]`, err);
-        if (mountedRef.current) {
-          setError(err.message);
-        }
-      })
-      .finally(() => {
-        if (mountedRef.current) setLoading(false);
-      });
+    try {
+      const map = await provider.fetchPullRequests(vendorAuth, vendorProject);
+      if (mountedRef.current) {
+        setPrMap(map);
+        setError(null);
+      }
+    } catch (err: unknown) {
+      const error = err as Error;
+      logError(`fetchPullRequests [${provider.id}]`, error);
+      if (mountedRef.current) {
+        setError(error.message);
+      }
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
   }, [vendorAuth, vendorProject, provider]);
 
   useEffect(() => {
     mountedRef.current = true;
     if (!provider || !provider.isConfigured(vendorAuth, vendorProject)) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial fetch must trigger on mount
-    refresh();
+    // Fire and forget — the initial fetch happens on mount. `refresh`
+    // now returns a promise, but we don't need to await it here; the
+    // state updates inside it are mount-guarded by `mountedRef`.
+    void refresh();
     const interval = setInterval(refresh, prPollInterval ?? refreshInterval);
     return () => {
       mountedRef.current = false;

--- a/apps/cli/src/hooks/useSessionManager.ts
+++ b/apps/cli/src/hooks/useSessionManager.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   removeWorktree,
   deleteBranch,
@@ -20,8 +20,6 @@ export function useSessionManager(
 ) {
   const [sessions, setSessions] = useState<AgentSession[]>([]);
   const [worktreeBranches, setWorktreeBranches] = useState<string[]>([]);
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const statusTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const refreshSessions = useCallback(async () => {
     const worktrees = await listWorktrees();
@@ -36,12 +34,6 @@ export function useSessionManager(
     setSessions(filtered);
     setWorktreeBranches(worktrees.map((wt) => wt.branch));
     return filtered;
-  }, []);
-
-  const flashStatus = useCallback((msg: string) => {
-    if (statusTimer.current) clearTimeout(statusTimer.current);
-    setStatusMessage(msg);
-    statusTimer.current = setTimeout(() => setStatusMessage(null), 3000);
   }, []);
 
   const performDelete = useCallback(
@@ -78,7 +70,6 @@ export function useSessionManager(
 
     return () => {
       cancelled = true;
-      if (statusTimer.current) clearTimeout(statusTimer.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -86,8 +77,6 @@ export function useSessionManager(
   return {
     sessions,
     worktreeBranches,
-    statusMessage,
-    flashStatus,
     refreshSessions,
     performDelete,
   };

--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -6,6 +6,7 @@ import { githubProvider } from '@kirby/vcs-github';
 import { StatusBar } from './components/StatusBar.js';
 import { DeleteConfirmModal } from './components/DeleteConfirmModal.js';
 import { ToastContainer } from './components/ToastContainer.js';
+import { AsyncOpsIndicator } from './components/AsyncOpsIndicator.js';
 import { OnboardingWizard } from './components/OnboardingWizard.js';
 import { killAll } from './pty-registry.js';
 import { ConfigProvider, useConfig } from './context/ConfigContext.js';
@@ -103,6 +104,7 @@ function App({ forceSetup }: { forceSetup: boolean }) {
           confirmInput={deleteConfirm.confirmInput}
         />
       )}
+      <AsyncOpsIndicator />
       <ToastContainer />
     </Box>
   );

--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { render, Box, useApp } from 'ink';
 import type { VcsProvider } from '@kirby/vcs-core';
 import { azureDevOpsProvider } from '@kirby/vcs-azure-devops';
 import { githubProvider } from '@kirby/vcs-github';
 import { StatusBar } from './components/StatusBar.js';
+import { DeleteConfirmModal } from './components/DeleteConfirmModal.js';
+import { ToastContainer } from './components/ToastContainer.js';
 import { OnboardingWizard } from './components/OnboardingWizard.js';
 import { killAll } from './pty-registry.js';
 import { ConfigProvider, useConfig } from './context/ConfigContext.js';
@@ -12,6 +14,7 @@ import { AppStateProvider, useAppState } from './context/AppStateContext.js';
 import { LayoutProvider, useLayout } from './context/LayoutContext.js';
 import { SessionProvider } from './context/SessionContext.js';
 import { SidebarProvider } from './context/SidebarContext.js';
+import { ToastProvider, useToastActions } from './context/ToastContext.js';
 import { MainTab } from './screens/main/MainTab.js';
 
 // ── Provider registry ──────────────────────────────────────────────
@@ -23,9 +26,47 @@ const providers: VcsProvider[] = [azureDevOpsProvider, githubProvider];
 function App({ forceSetup }: { forceSetup: boolean }) {
   const { exit } = useApp();
   const { config, provider, vcsConfigured } = useConfig();
-  const { nav } = useAppState();
+  const { nav, deleteConfirm } = useAppState();
   const { termRows } = useLayout();
+  const { flash } = useToastActions();
   const [onboardingComplete, setOnboardingComplete] = useState(false);
+
+  // Dev-only visual test harness for the toast stack. Gated on
+  // `KIRBY_TOAST_DEMO=1` so it has zero overhead in normal use. Every
+  // 4s fires a burst of 1–6 toasts with a random stagger — short bursts
+  // show one or two toasts at a time, long bursts blow past the 5-cap
+  // so you can watch the oldest toast get evicted.
+  useEffect(() => {
+    if (process.env.KIRBY_TOAST_DEMO !== '1') return;
+    const variants = ['info', 'success', 'warning', 'error'] as const;
+    const words =
+      'the quick brown fox jumps over the lazy dog in a terminal window today for visual testing purposes'.split(
+        ' '
+      );
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+    const id = setInterval(() => {
+      const burst = 1 + Math.floor(Math.random() * 6);
+      for (let i = 0; i < burst; i++) {
+        const delay = i * (100 + Math.floor(Math.random() * 200));
+        timeouts.push(
+          setTimeout(() => {
+            const variant =
+              variants[Math.floor(Math.random() * variants.length)]!;
+            const length = 2 + Math.floor(Math.random() * 12);
+            const message = Array.from(
+              { length },
+              () => words[Math.floor(Math.random() * words.length)]!
+            ).join(' ');
+            flash(message, variant);
+          }, delay)
+        );
+      }
+    }, 4000);
+    return () => {
+      clearInterval(id);
+      for (const t of timeouts) clearTimeout(t);
+    };
+  }, [flash]);
 
   const showOnboarding =
     !onboardingComplete &&
@@ -55,6 +96,14 @@ function App({ forceSetup }: { forceSetup: boolean }) {
       <Box flexShrink={0} paddingX={1}>
         <StatusBar />
       </Box>
+      {deleteConfirm.confirmDelete && (
+        <DeleteConfirmModal
+          branch={deleteConfirm.confirmDelete.branch}
+          reason={deleteConfirm.confirmDelete.reason}
+          confirmInput={deleteConfirm.confirmInput}
+        />
+      )}
+      <ToastContainer />
     </Box>
   );
 }
@@ -91,11 +140,13 @@ render(
     <KeybindProvider>
       <LayoutProvider>
         <AppStateProvider>
-          <SessionProvider>
-            <SidebarProvider>
-              <App forceSetup={forceSetup} />
-            </SidebarProvider>
-          </SessionProvider>
+          <ToastProvider>
+            <SessionProvider>
+              <SidebarProvider>
+                <App forceSetup={forceSetup} />
+              </SidebarProvider>
+            </SessionProvider>
+          </ToastProvider>
         </AppStateProvider>
       </LayoutProvider>
     </KeybindProvider>

--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { render, Box, useApp } from 'ink';
 import type { VcsProvider } from '@kirby/vcs-core';
 import { azureDevOpsProvider } from '@kirby/vcs-azure-devops';
@@ -15,7 +15,7 @@ import { AppStateProvider, useAppState } from './context/AppStateContext.js';
 import { LayoutProvider, useLayout } from './context/LayoutContext.js';
 import { SessionProvider } from './context/SessionContext.js';
 import { SidebarProvider } from './context/SidebarContext.js';
-import { ToastProvider, useToastActions } from './context/ToastContext.js';
+import { ToastProvider } from './context/ToastContext.js';
 import { MainTab } from './screens/main/MainTab.js';
 
 // ── Provider registry ──────────────────────────────────────────────
@@ -29,45 +29,7 @@ function App({ forceSetup }: { forceSetup: boolean }) {
   const { config, provider, vcsConfigured } = useConfig();
   const { nav, deleteConfirm } = useAppState();
   const { termRows } = useLayout();
-  const { flash } = useToastActions();
   const [onboardingComplete, setOnboardingComplete] = useState(false);
-
-  // Dev-only visual test harness for the toast stack. Gated on
-  // `KIRBY_TOAST_DEMO=1` so it has zero overhead in normal use. Every
-  // 4s fires a burst of 1–6 toasts with a random stagger — short bursts
-  // show one or two toasts at a time, long bursts blow past the 5-cap
-  // so you can watch the oldest toast get evicted.
-  useEffect(() => {
-    if (process.env.KIRBY_TOAST_DEMO !== '1') return;
-    const variants = ['info', 'success', 'warning', 'error'] as const;
-    const words =
-      'the quick brown fox jumps over the lazy dog in a terminal window today for visual testing purposes'.split(
-        ' '
-      );
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
-    const id = setInterval(() => {
-      const burst = 1 + Math.floor(Math.random() * 6);
-      for (let i = 0; i < burst; i++) {
-        const delay = i * (100 + Math.floor(Math.random() * 200));
-        timeouts.push(
-          setTimeout(() => {
-            const variant =
-              variants[Math.floor(Math.random() * variants.length)]!;
-            const length = 2 + Math.floor(Math.random() * 12);
-            const message = Array.from(
-              { length },
-              () => words[Math.floor(Math.random() * words.length)]!
-            ).join(' ');
-            flash(message, variant);
-          }, delay)
-        );
-      }
-    }, 4000);
-    return () => {
-      clearInterval(id);
-      for (const t of timeouts) clearTimeout(t);
-    };
-  }, [flash]);
 
   const showOnboarding =
     !onboardingComplete &&

--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { render, Text, Box, useApp } from 'ink';
+import { render, Box, useApp } from 'ink';
 import type { VcsProvider } from '@kirby/vcs-core';
 import { azureDevOpsProvider } from '@kirby/vcs-azure-devops';
 import { githubProvider } from '@kirby/vcs-github';
@@ -45,19 +45,15 @@ function App({ forceSetup }: { forceSetup: boolean }) {
 
   return (
     <Box flexDirection="column" height={termRows}>
-      <Box paddingX={1} justifyContent="space-between" marginBottom={1}>
-        <Box gap={2}>
-          <Text bold>😸 Kirby</Text>
-          <StatusBar />
-        </Box>
-        <Text dimColor>{process.cwd()}</Text>
-      </Box>
       <Box flexGrow={1}>
         <MainTab
           terminalFocused={terminalFocused}
           showOnboarding={showOnboarding}
           exit={exit}
         />
+      </Box>
+      <Box flexShrink={0} paddingX={1}>
+        <StatusBar />
       </Box>
     </Box>
   );

--- a/apps/cli/src/screens/main/DiffPane.tsx
+++ b/apps/cli/src/screens/main/DiffPane.tsx
@@ -6,6 +6,7 @@ import { DiffViewer } from '../reviews/DiffViewer.js';
 import { useSessionActions } from '../../context/SessionContext.js';
 import { useConfig } from '../../context/ConfigContext.js';
 import { useKeybinds } from '../../context/KeybindContext.js';
+import { useAppState } from '../../context/AppStateContext.js';
 import type { TerminalLayout } from '../../context/LayoutContext.js';
 import type { PaneModeValue } from '../../hooks/usePaneReducer.js';
 import { useDiffData } from '../../hooks/useDiffData.js';
@@ -37,6 +38,7 @@ export function DiffPane({
   const sessionCtx = useSessionActions();
   const configCtx = useConfig();
   const keybinds = useKeybinds();
+  const { asyncOps } = useAppState();
 
   // ── Review comments (file-watched) ────────────────────────────
   const reviewComments = useReviewComments(selectedPr?.id ?? null);
@@ -164,6 +166,7 @@ export function DiffPane({
             : undefined,
           config: configCtx,
           sessions: sessionCtx,
+          asyncOps,
           keybinds,
         });
       }

--- a/apps/cli/src/screens/main/MainContent.tsx
+++ b/apps/cli/src/screens/main/MainContent.tsx
@@ -1,0 +1,108 @@
+import type { PullRequestInfo } from '@kirby/vcs-core';
+import { BranchPicker } from '../sessions/BranchPicker.js';
+import { SettingsPanel } from '../../components/SettingsPanel.js';
+import { ControlsPanel } from '../../components/ControlsPanel.js';
+import { ReviewConfirmPane } from '../reviews/ReviewConfirmPane.js';
+import { ReviewDetailPane } from '../reviews/ReviewDetailPane.js';
+import { TerminalPane } from './TerminalPane.js';
+import { DiffPane } from './DiffPane.js';
+import type { TerminalLayout } from '../../context/LayoutContext.js';
+import type { PaneModeValue } from '../../hooks/usePaneReducer.js';
+import { useAppState } from '../../context/AppStateContext.js';
+
+interface MainContentProps {
+  pane: PaneModeValue;
+  terminal: TerminalLayout;
+  terminalFocused: boolean;
+  sessionNameForTerminal: string | null;
+  selectedPr: PullRequestInfo | undefined;
+  onFocusSidebar: () => void;
+}
+
+// Pure router for the main content pane. Renders exactly one of the
+// mutually-exclusive sub-panes based on modal and pane-mode state, in
+// the same precedence order MainTab used to inline. Extracted from
+// MainTab so MainTab can focus on the layout shell (Sidebar + Pane +
+// DeleteConfirmModal) without drowning in conditional JSX.
+//
+// Precedence (highest first):
+//   1. Controls sub-screen  → ControlsPanel
+//   2. Settings             → SettingsPanel
+//   3. Branch picker        → BranchPicker
+//   4. Review confirm       → ReviewConfirmPane
+//   5. Terminal mode        → TerminalPane
+//   6. PR detail mode       → ReviewDetailPane
+//   7. Diff mode            → DiffPane
+export function MainContent({
+  pane,
+  terminal,
+  terminalFocused,
+  sessionNameForTerminal,
+  selectedPr,
+  onFocusSidebar,
+}: MainContentProps) {
+  const { settings, branchPicker } = useAppState();
+
+  if (settings.settingsOpen && settings.controlsOpen) {
+    return (
+      <ControlsPanel
+        paneRows={terminal.paneRows}
+        selectedIndex={settings.controlsSelectedIndex}
+        rebindActionId={settings.controlsRebindActionId}
+      />
+    );
+  }
+  if (settings.settingsOpen) {
+    return (
+      <SettingsPanel
+        fieldIndex={settings.settingsFieldIndex}
+        editingField={settings.editingField}
+        editBuffer={settings.editBuffer}
+      />
+    );
+  }
+  if (branchPicker.creating) {
+    return (
+      <BranchPicker
+        filter={branchPicker.branchFilter}
+        branches={branchPicker.branches}
+        selectedIndex={branchPicker.branchIndex}
+        paneRows={terminal.paneRows}
+      />
+    );
+  }
+  if (pane.reviewConfirm) {
+    return (
+      <ReviewConfirmPane
+        pr={pane.reviewConfirm.pr}
+        selectedOption={pane.reviewConfirm.selectedOption}
+        instruction={pane.reviewInstruction}
+      />
+    );
+  }
+  if (pane.paneMode === 'terminal') {
+    return (
+      <TerminalPane
+        sessionNameForTerminal={sessionNameForTerminal}
+        terminal={terminal}
+        reconnectKey={pane.reconnectKey}
+        terminalFocused={terminalFocused}
+        onFocusSidebar={onFocusSidebar}
+      />
+    );
+  }
+  if (pane.paneMode === 'pr-detail') {
+    return <ReviewDetailPane pr={selectedPr} />;
+  }
+  if (pane.paneMode === 'diff' || pane.paneMode === 'diff-file') {
+    return (
+      <DiffPane
+        pane={pane}
+        terminal={terminal}
+        selectedPr={selectedPr}
+        terminalFocused={terminalFocused}
+      />
+    );
+  }
+  return null;
+}

--- a/apps/cli/src/screens/main/MainContent.tsx
+++ b/apps/cli/src/screens/main/MainContent.tsx
@@ -23,7 +23,7 @@ interface MainContentProps {
 // mutually-exclusive sub-panes based on modal and pane-mode state, in
 // the same precedence order MainTab used to inline. Extracted from
 // MainTab so MainTab can focus on the layout shell (Sidebar + Pane +
-// DeleteConfirmModal) without drowning in conditional JSX.
+// DeleteConfirmModal overlay) without drowning in conditional JSX.
 //
 // Precedence (highest first):
 //   1. Controls sub-screen  → ControlsPanel

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -151,6 +151,7 @@ export function MainTab({
     aiCommand: configCtx.config.aiCommand,
     prTitle: sidebar.selectedPr?.title,
     sessionName: sidebar.sessionNameForTerminal,
+    terminalFocused,
   });
 
   // Auto-hide the sidebar while the user is driving an agent session or

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -1,12 +1,8 @@
 import { useInput } from 'ink';
 import { Sidebar } from '../../components/Sidebar.js';
-import { BranchPicker } from '../sessions/BranchPicker.js';
-import { SettingsPanel } from '../../components/SettingsPanel.js';
-import { ControlsPanel } from '../../components/ControlsPanel.js';
-import { ReviewConfirmPane } from '../reviews/ReviewConfirmPane.js';
-import { ReviewDetailPane } from '../reviews/ReviewDetailPane.js';
+import { Pane } from '../../components/Pane.js';
 import { useAppState } from '../../context/AppStateContext.js';
-import { useLayout } from '../../context/LayoutContext.js';
+import { useLayout, LAYOUT } from '../../context/LayoutContext.js';
 import { useSessionActions } from '../../context/SessionContext.js';
 import { useConfig } from '../../context/ConfigContext.js';
 import { useKeybinds } from '../../context/KeybindContext.js';
@@ -22,8 +18,8 @@ import {
   handleConfirmInput,
   handleSidebarInput,
 } from './main-input.js';
-import { TerminalPane } from './TerminalPane.js';
-import { DiffPane } from './DiffPane.js';
+import { MainContent } from './MainContent.js';
+import { getMainFocused, getSidebarFocused, getPaneTitle } from './focus.js';
 
 interface MainTabProps {
   terminalFocused: boolean;
@@ -130,15 +126,37 @@ export function MainTab({
   });
 
   // ── Render ─────────────────────────────────────────────────────
-  const sidebarFocused =
-    nav.focus === 'sidebar' &&
-    !branchPicker.creating &&
-    !settings.settingsOpen &&
-    !pane.reviewConfirm;
+  // Single source of truth for which pane shows the active border color.
+  // Both getMainFocused and getSidebarFocused are pure helpers (see
+  // ./focus.ts) that stay aligned with the actual input sink — crucially,
+  // diff modes count as main-focused because DiffPane.useInput is the
+  // real input handler there, not the sidebar.
+  const focusState = {
+    navFocus: nav.focus,
+    paneMode: pane.paneMode,
+    branchPickerCreating: branchPicker.creating,
+    settingsOpen: settings.settingsOpen,
+    reviewConfirmActive: pane.reviewConfirm !== null,
+    deleteConfirmActive: deleteConfirm.confirmDelete !== null,
+  };
+  const mainFocused = getMainFocused(focusState);
+  const sidebarFocused = getSidebarFocused(focusState);
+
+  const paneTitle = getPaneTitle({
+    paneMode: pane.paneMode,
+    branchPickerCreating: branchPicker.creating,
+    settingsOpen: settings.settingsOpen,
+    controlsOpen: settings.controlsOpen,
+    reviewConfirmActive: pane.reviewConfirm !== null,
+    aiCommand: configCtx.config.aiCommand,
+    prTitle: sidebar.selectedPr?.title,
+    sessionName: sidebar.sessionNameForTerminal,
+  });
 
   // Auto-hide the sidebar while the user is driving an agent session or
   // scanning a diff, so the content pane can reclaim the full width.
-  // undefined → default on; explicit false opts out.
+  // undefined → default on; explicit false opts out. (Feature from
+  // commit 06bd627 — preserved verbatim except for constant reuse.)
   const autoHideEnabled = configCtx.config.autoHideSidebar !== false;
   const hideablePaneMode =
     pane.paneMode === 'terminal' ||
@@ -149,7 +167,7 @@ export function MainTab({
 
   const effectiveTerminal = sidebarHidden
     ? {
-        paneCols: Math.max(20, layout.termCols - 2),
+        paneCols: Math.max(20, layout.termCols - LAYOUT.PANE_BORDER_COLS),
         paneRows: terminal.paneRows,
       }
     : terminal;
@@ -165,60 +183,16 @@ export function MainTab({
           focused={sidebarFocused}
         />
       )}
-      {settings.settingsOpen && settings.controlsOpen && (
-        <ControlsPanel
-          paneRows={terminal.paneRows}
-          selectedIndex={settings.controlsSelectedIndex}
-          rebindActionId={settings.controlsRebindActionId}
+      <Pane focused={mainFocused} title={paneTitle} flexGrow={1}>
+        <MainContent
+          pane={pane}
+          terminal={effectiveTerminal}
+          terminalFocused={terminalFocused}
+          sessionNameForTerminal={sidebar.sessionNameForTerminal}
+          selectedPr={sidebar.selectedPr}
+          onFocusSidebar={() => nav.setFocus('sidebar')}
         />
-      )}
-      {settings.settingsOpen && !settings.controlsOpen && (
-        <SettingsPanel
-          fieldIndex={settings.settingsFieldIndex}
-          editingField={settings.editingField}
-          editBuffer={settings.editBuffer}
-        />
-      )}
-      {!settings.settingsOpen && branchPicker.creating && (
-        <BranchPicker
-          filter={branchPicker.branchFilter}
-          branches={branchPicker.branches}
-          selectedIndex={branchPicker.branchIndex}
-          paneRows={terminal.paneRows}
-        />
-      )}
-      {!settings.settingsOpen && !branchPicker.creating && (
-        <>
-          {pane.reviewConfirm && (
-            <ReviewConfirmPane
-              pr={pane.reviewConfirm.pr}
-              selectedOption={pane.reviewConfirm.selectedOption}
-              instruction={pane.reviewInstruction}
-            />
-          )}
-          {!pane.reviewConfirm && pane.paneMode === 'terminal' && (
-            <TerminalPane
-              sessionNameForTerminal={sidebar.sessionNameForTerminal}
-              terminal={effectiveTerminal}
-              reconnectKey={pane.reconnectKey}
-              terminalFocused={terminalFocused}
-              onFocusSidebar={() => nav.setFocus('sidebar')}
-            />
-          )}
-          {!pane.reviewConfirm && pane.paneMode === 'pr-detail' && (
-            <ReviewDetailPane pr={sidebar.selectedPr} />
-          )}
-          {!pane.reviewConfirm &&
-            (pane.paneMode === 'diff' || pane.paneMode === 'diff-file') && (
-              <DiffPane
-                pane={pane}
-                terminal={effectiveTerminal}
-                selectedPr={sidebar.selectedPr}
-                terminalFocused={terminalFocused}
-              />
-            )}
-        </>
-      )}
+      </Pane>
     </>
   );
 }

--- a/apps/cli/src/screens/main/TerminalPane.tsx
+++ b/apps/cli/src/screens/main/TerminalPane.tsx
@@ -26,5 +26,5 @@ export function TerminalPane({
     onFocusSidebar
   );
 
-  return <TerminalView content={content} focused={terminalFocused} />;
+  return <TerminalView content={content} />;
 }

--- a/apps/cli/src/screens/main/branch-picker-input.ts
+++ b/apps/cli/src/screens/main/branch-picker-input.ts
@@ -39,7 +39,8 @@ export function handleBranchPickerInput(
 
   if (action === 'branch-picker.fetch') {
     ctx.asyncOps.run('fetch-branches', async () => {
-      ctx.sessions.flashStatus('Fetching remotes...');
+      // No "Fetching remotes…" flash — the 'fetch-branches' spinner
+      // (label: "Fetching branches") already shows we're working.
       await fetchRemote();
       const allBranches = await listAllBranches();
       ctx.branchPicker.setBranches(allBranches);

--- a/apps/cli/src/screens/main/confirm-delete-input.ts
+++ b/apps/cli/src/screens/main/confirm-delete-input.ts
@@ -18,11 +18,13 @@ export function handleConfirmDeleteInput(
     if (
       ctx.deleteConfirm.confirmInput === ctx.deleteConfirm.confirmDelete!.branch
     ) {
+      // Capture the names before clearing the modal state below — the
+      // async runs after setConfirmDelete(null), and we need these for
+      // the success toast too.
+      const { sessionName, branch } = ctx.deleteConfirm.confirmDelete!;
       ctx.asyncOps.run('delete', async () => {
-        await ctx.sessions.performDelete(
-          ctx.deleteConfirm.confirmDelete!.sessionName,
-          ctx.deleteConfirm.confirmDelete!.branch
-        );
+        await ctx.sessions.performDelete(sessionName, branch);
+        ctx.sessions.flashStatus(`Deleted ${branch}`);
       });
     } else {
       ctx.sessions.flashStatus('Branch name did not match — delete cancelled');

--- a/apps/cli/src/screens/main/diff-viewer-input.ts
+++ b/apps/cli/src/screens/main/diff-viewer-input.ts
@@ -281,11 +281,14 @@ export function handleDiffViewerInput(
 
     const postedId = comment.id;
     const prId = ctx.commentCtx.prId;
+    const commentCtx = ctx.commentCtx;
     updateComment(prId, postedId, { status: 'posting' });
-    ctx.sessions.flashStatus('Posting comment...');
 
-    postReviewComments([comment], postCtx)
-      .then(() => {
+    // Loading state shown by the top-right spinner; no "Posting
+    // comment…" flash. Result/failure toasts fire on completion.
+    ctx.asyncOps.run('post-comment', async () => {
+      try {
+        await postReviewComments([comment], postCtx);
         ctx.sessions.flashStatus('Comment posted');
         const freshComments = readComments(prId).filter(
           (c) => c.file === ctx.pane.diffViewFile
@@ -294,7 +297,7 @@ export function handleDiffViewerInput(
           'next',
           postedId,
           freshComments,
-          ctx.commentCtx?.positions,
+          commentCtx.positions,
           (c) => c.status === 'draft'
         );
         if (nextDraftId) {
@@ -303,11 +306,11 @@ export function handleDiffViewerInput(
         } else {
           ctx.pane.setSelectedCommentId(null);
         }
-      })
-      .catch((err: Error) => {
+      } catch (err) {
         updateComment(prId, postedId, { status: 'draft' });
-        ctx.sessions.flashStatus(`Post failed: ${err.message}`);
-      });
+        ctx.sessions.flashStatus(`Post failed: ${(err as Error).message}`);
+      }
+    });
     return;
   }
 

--- a/apps/cli/src/screens/main/focus.spec.ts
+++ b/apps/cli/src/screens/main/focus.spec.ts
@@ -25,6 +25,7 @@ const baseTitle: PaneTitleState = {
   aiCommand: undefined,
   prTitle: undefined,
   sessionName: null,
+  terminalFocused: false,
 };
 
 describe('getMainFocused', () => {
@@ -142,6 +143,32 @@ describe('getPaneTitle', () => {
         sessionName: 'x',
       })
     ).toBe('\u{1F916} Claude \u2014 x');
+  });
+
+  it('appends the ctrl+space hint when the terminal is focused', () => {
+    expect(
+      getPaneTitle({
+        ...baseTitle,
+        sessionName: 'feature-foo',
+        terminalFocused: true,
+      })
+    ).toBe('\u{1F916} Claude \u2014 feature-foo (ctrl+space to exit)');
+  });
+
+  it('appends the hint even without a session label', () => {
+    expect(getPaneTitle({ ...baseTitle, terminalFocused: true })).toBe(
+      '\u{1F916} Claude (ctrl+space to exit)'
+    );
+  });
+
+  it('does not append the hint outside terminal mode', () => {
+    expect(
+      getPaneTitle({
+        ...baseTitle,
+        paneMode: 'diff',
+        terminalFocused: true,
+      })
+    ).toBe('Files Changed');
   });
 
   // ── Non-terminal modes (unchanged from before) ──────────────────

--- a/apps/cli/src/screens/main/focus.spec.ts
+++ b/apps/cli/src/screens/main/focus.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getMainFocused,
+  getSidebarFocused,
+  getPaneTitle,
+  type FocusState,
+  type PaneTitleState,
+} from './focus.js';
+
+const baseFocus: FocusState = {
+  navFocus: 'sidebar',
+  paneMode: 'terminal',
+  branchPickerCreating: false,
+  settingsOpen: false,
+  reviewConfirmActive: false,
+  deleteConfirmActive: false,
+};
+
+const baseTitle: PaneTitleState = {
+  paneMode: 'terminal',
+  branchPickerCreating: false,
+  settingsOpen: false,
+  controlsOpen: false,
+  reviewConfirmActive: false,
+  aiCommand: undefined,
+  prTitle: undefined,
+  sessionName: null,
+};
+
+describe('getMainFocused', () => {
+  it('is false when nav.focus is sidebar and nothing else is active', () => {
+    expect(getMainFocused(baseFocus)).toBe(false);
+  });
+
+  it('is true when nav.focus is terminal', () => {
+    expect(getMainFocused({ ...baseFocus, navFocus: 'terminal' })).toBe(true);
+  });
+
+  it('is true in diff mode even when nav.focus is sidebar (visual/input alignment)', () => {
+    // Regression guard: DiffPane's useInput is the real input sink in
+    // diff mode, so the main pane must show as focused.
+    expect(getMainFocused({ ...baseFocus, paneMode: 'diff' })).toBe(true);
+    expect(getMainFocused({ ...baseFocus, paneMode: 'diff-file' })).toBe(true);
+  });
+
+  it('is true when the branch picker is open', () => {
+    expect(getMainFocused({ ...baseFocus, branchPickerCreating: true })).toBe(
+      true
+    );
+  });
+
+  it('is true when settings are open', () => {
+    expect(getMainFocused({ ...baseFocus, settingsOpen: true })).toBe(true);
+  });
+
+  it('is true when the review confirm overlay is active', () => {
+    expect(getMainFocused({ ...baseFocus, reviewConfirmActive: true })).toBe(
+      true
+    );
+  });
+
+  it('is false when the delete confirm modal owns focus', () => {
+    // The modal takes focus exclusively — neither pane is highlighted.
+    expect(
+      getMainFocused({
+        ...baseFocus,
+        navFocus: 'terminal',
+        deleteConfirmActive: true,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('getSidebarFocused', () => {
+  it('is the inverse of getMainFocused in normal modes', () => {
+    expect(getSidebarFocused(baseFocus)).toBe(true);
+    expect(getSidebarFocused({ ...baseFocus, navFocus: 'terminal' })).toBe(
+      false
+    );
+    expect(getSidebarFocused({ ...baseFocus, paneMode: 'diff' })).toBe(false);
+  });
+
+  it('is false when the delete confirm modal owns focus', () => {
+    expect(getSidebarFocused({ ...baseFocus, deleteConfirmActive: true })).toBe(
+      false
+    );
+  });
+});
+
+describe('getPaneTitle', () => {
+  // ── Terminal mode (default) — 🤖 AgentName — label ──────────────
+
+  it('defaults to "🤖 Claude" when no session, no aiCommand configured', () => {
+    expect(getPaneTitle(baseTitle)).toBe('\u{1F916} Claude');
+  });
+
+  it('shows "🤖 Claude — branch" with a session name (default agent)', () => {
+    expect(getPaneTitle({ ...baseTitle, sessionName: 'feature-foo' })).toBe(
+      '\u{1F916} Claude \u2014 feature-foo'
+    );
+  });
+
+  it('prefers PR title over session name', () => {
+    expect(
+      getPaneTitle({
+        ...baseTitle,
+        sessionName: 'feature-foo',
+        prTitle: 'Fix navigation bug',
+      })
+    ).toBe('\u{1F916} Claude \u2014 Fix navigation bug');
+  });
+
+  it('resolves agent name from aiCommand using AI_PRESETS', () => {
+    expect(
+      getPaneTitle({ ...baseTitle, aiCommand: 'codex', sessionName: 'branch' })
+    ).toBe('\u{1F916} Codex \u2014 branch');
+
+    expect(getPaneTitle({ ...baseTitle, aiCommand: 'gemini' })).toBe(
+      '\u{1F916} Gemini'
+    );
+
+    expect(
+      getPaneTitle({ ...baseTitle, aiCommand: 'gh copilot', sessionName: 'x' })
+    ).toBe('\u{1F916} Copilot \u2014 x');
+  });
+
+  it('falls back to "Agent" for custom/unrecognized aiCommand', () => {
+    expect(
+      getPaneTitle({
+        ...baseTitle,
+        aiCommand: 'my-custom-tool --flag',
+        sessionName: 'branch',
+      })
+    ).toBe('\u{1F916} Agent \u2014 branch');
+  });
+
+  it('uses the full default command string for Claude', () => {
+    expect(
+      getPaneTitle({
+        ...baseTitle,
+        aiCommand: 'claude --continue || claude',
+        sessionName: 'x',
+      })
+    ).toBe('\u{1F916} Claude \u2014 x');
+  });
+
+  // ── Non-terminal modes (unchanged from before) ──────────────────
+
+  it('returns "Files Changed" in diff modes', () => {
+    expect(getPaneTitle({ ...baseTitle, paneMode: 'diff' })).toBe(
+      'Files Changed'
+    );
+    expect(getPaneTitle({ ...baseTitle, paneMode: 'diff-file' })).toBe(
+      'Files Changed'
+    );
+  });
+
+  it('returns "Pull Request" in pr-detail mode', () => {
+    expect(getPaneTitle({ ...baseTitle, paneMode: 'pr-detail' })).toBe(
+      'Pull Request'
+    );
+  });
+
+  it('returns "New Session" when the branch picker is open', () => {
+    expect(getPaneTitle({ ...baseTitle, branchPickerCreating: true })).toBe(
+      'New Session'
+    );
+  });
+
+  it('returns "Settings" when settings are open', () => {
+    expect(getPaneTitle({ ...baseTitle, settingsOpen: true })).toBe('Settings');
+  });
+
+  it('returns "Controls" when controls sub-screen is open (takes precedence over Settings)', () => {
+    expect(
+      getPaneTitle({ ...baseTitle, settingsOpen: true, controlsOpen: true })
+    ).toBe('Controls');
+  });
+
+  it('returns "Confirm Review" when the review confirm overlay is active', () => {
+    expect(getPaneTitle({ ...baseTitle, reviewConfirmActive: true })).toBe(
+      'Confirm Review'
+    );
+  });
+});

--- a/apps/cli/src/screens/main/focus.ts
+++ b/apps/cli/src/screens/main/focus.ts
@@ -59,6 +59,11 @@ export interface PaneTitleState {
   aiCommand: string | undefined;
   prTitle: string | undefined;
   sessionName: string | null;
+  /**
+   * When true AND we're in terminal mode, the title appends a
+   * `· ctrl+space to exit` hint so the user knows how to escape.
+   */
+  terminalFocused: boolean;
 }
 
 /**
@@ -67,8 +72,9 @@ export interface PaneTitleState {
  *
  * In terminal mode the title becomes:
  *   🤖 Claude — Fix navigation bug   (PR title available)
- *   🤖 Claude — feature-foo          (no PR, falls back to session/branch name)
+ *   🤖 Claude — feature-foo          (no PR, session/branch name)
  *   🤖 Claude                        (no session selected)
+ *   …with ` · ctrl+space to exit` appended when terminalFocused.
  */
 export function getPaneTitle(s: PaneTitleState): string {
   if (s.controlsOpen) return 'Controls';
@@ -81,6 +87,8 @@ export function getPaneTitle(s: PaneTitleState): string {
 
   const agent = resolvePresetName(s.aiCommand, AI_PRESETS, 'Agent');
   const label = s.prTitle || s.sessionName;
-  if (label) return `\u{1F916} ${agent} \u2014 ${label}`;
-  return `\u{1F916} ${agent}`;
+  const base = label
+    ? `\u{1F916} ${agent} \u2014 ${label}`
+    : `\u{1F916} ${agent}`;
+  return s.terminalFocused ? `${base} (ctrl+space to exit)` : base;
 }

--- a/apps/cli/src/screens/main/focus.ts
+++ b/apps/cli/src/screens/main/focus.ts
@@ -1,0 +1,86 @@
+// Pure helpers that decide which pane (sidebar or main) is visually
+// "focused" and what title the main pane should display. Extracted from
+// MainTab.tsx so the rules live in one place, are easy to unit-test, and
+// can't silently drift out of sync with input-handler behavior.
+//
+// The rules stay in sync with two things:
+//   1. The actual input sink — whichever handler's useInput fires.
+//   2. The auto-hide sidebar feature (commit 06bd627), which only hides
+//      the sidebar when nav.focus === 'terminal'. Our helpers must agree
+//      that the sidebar is NOT focused in those cases.
+
+import type { Focus, PaneMode } from '../../types.js';
+import { resolvePresetName } from '../../utils/resolve-preset-name.js';
+import { AI_PRESETS } from '../../components/SettingsPanel.js';
+
+export interface FocusState {
+  navFocus: Focus;
+  paneMode: PaneMode;
+  branchPickerCreating: boolean;
+  settingsOpen: boolean;
+  reviewConfirmActive: boolean;
+  deleteConfirmActive: boolean;
+}
+
+/**
+ * Returns true when the main content pane should render with the active
+ * border color. Precedence (highest first):
+ *   1. Delete confirm modal → NEITHER pane is focused (modal owns focus).
+ *   2. Any modal-ish state (branch picker, settings, review confirm) →
+ *      main pane, because that's where the modal content renders.
+ *   3. Diff modes → main pane, because DiffPane's useInput is the sink.
+ *   4. Otherwise → whichever side nav.focus points at.
+ */
+export function getMainFocused(s: FocusState): boolean {
+  if (s.deleteConfirmActive) return false;
+  if (s.branchPickerCreating) return true;
+  if (s.settingsOpen) return true;
+  if (s.reviewConfirmActive) return true;
+  if (s.paneMode === 'diff' || s.paneMode === 'diff-file') return true;
+  return s.navFocus === 'terminal';
+}
+
+/**
+ * Returns true when the sidebar should render with the active border color.
+ * When a delete confirm modal is open, neither pane is focused — the modal
+ * has keyboard focus exclusively.
+ */
+export function getSidebarFocused(s: FocusState): boolean {
+  if (s.deleteConfirmActive) return false;
+  return !getMainFocused(s);
+}
+
+export interface PaneTitleState {
+  paneMode: PaneMode;
+  branchPickerCreating: boolean;
+  settingsOpen: boolean;
+  controlsOpen: boolean;
+  reviewConfirmActive: boolean;
+  aiCommand: string | undefined;
+  prTitle: string | undefined;
+  sessionName: string | null;
+}
+
+/**
+ * Human-readable title for the main pane. Precedence matches the render
+ * precedence in MainTab / MainContent.
+ *
+ * In terminal mode the title becomes:
+ *   🤖 Claude — Fix navigation bug   (PR title available)
+ *   🤖 Claude — feature-foo          (no PR, falls back to session/branch name)
+ *   🤖 Claude                        (no session selected)
+ */
+export function getPaneTitle(s: PaneTitleState): string {
+  if (s.controlsOpen) return 'Controls';
+  if (s.settingsOpen) return 'Settings';
+  if (s.branchPickerCreating) return 'New Session';
+  if (s.reviewConfirmActive) return 'Confirm Review';
+  if (s.paneMode === 'pr-detail') return 'Pull Request';
+  if (s.paneMode === 'diff' || s.paneMode === 'diff-file')
+    return 'Files Changed';
+
+  const agent = resolvePresetName(s.aiCommand, AI_PRESETS, 'Agent');
+  const label = s.prTitle || s.sessionName;
+  if (label) return `\u{1F916} ${agent} \u2014 ${label}`;
+  return `\u{1F916} ${agent}`;
+}

--- a/apps/cli/src/screens/main/input-types.ts
+++ b/apps/cli/src/screens/main/input-types.ts
@@ -61,6 +61,7 @@ export interface DiffViewerHandlerCtx {
   commentCtx?: CommentContext;
   config: ConfigContextValue;
   sessions: SessionActionsContextValue;
+  asyncOps: AsyncOpsValue;
   keybinds: KeybindContextValue;
 }
 

--- a/apps/cli/src/screens/main/sidebar-input.ts
+++ b/apps/cli/src/screens/main/sidebar-input.ts
@@ -160,10 +160,11 @@ export function handleSidebarInput(
     return;
   }
 
-  // Refresh PR data
+  // Refresh PR data — loading state shown by the top-right spinner.
   if (action === 'sidebar.refresh-pr') {
-    ctx.sessions.refreshPr();
-    ctx.sessions.flashStatus('Refreshing PR data...');
+    ctx.asyncOps.run('refresh-pr', async () => {
+      await ctx.sessions.refreshPr();
+    });
     return;
   }
 
@@ -179,7 +180,8 @@ export function handleSidebarInput(
         ctx.sessions.flashStatus('No worktree found for selected session');
         return;
       }
-      ctx.sessions.flashStatus('Updating from origin...');
+      // No "Updating from origin…" flash — the 'rebase' spinner
+      // (label: "Rebasing") already communicates that we're working.
       const rebaseMessages = {
         success: 'Rebased onto origin successfully',
         conflict: 'Conflicts detected — rebase aborted',
@@ -214,10 +216,11 @@ export function handleSidebarInput(
     return;
   }
 
-  // Sync with origin
+  // Sync with origin — loading state shown by the top-right spinner.
   if (action === 'sidebar.sync-origin') {
-    ctx.sessions.flashStatus('Syncing with origin...');
-    ctx.sessions.triggerSync();
+    ctx.asyncOps.run('sync', async () => {
+      await ctx.sessions.triggerSync();
+    });
     return;
   }
 

--- a/apps/cli/src/theme.ts
+++ b/apps/cli/src/theme.ts
@@ -1,0 +1,11 @@
+// Visual constants shared by Pane and any component that needs to match
+// the active/inactive focus colors. Plain module export — no React context,
+// no hook churn. Contexts are for mutable state; constants belong in modules.
+
+export const theme = {
+  border: {
+    style: 'round' as const,
+    active: 'cyan' as const,
+    inactive: 'gray' as const,
+  },
+} as const;

--- a/apps/cli/src/utils/resolve-preset-name.ts
+++ b/apps/cli/src/utils/resolve-preset-name.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolve a config value to a human-readable preset name.
+ *
+ * Matches `value` against the presets array (same shape as SettingsPanel
+ * presets). Returns the matched preset's `name`, or `fallback` for
+ * unrecognized custom values. When `value` is undefined/empty, returns
+ * the first preset's name (the default).
+ */
+export function resolvePresetName(
+  value: string | undefined,
+  presets: readonly { name: string; value: string | null }[],
+  fallback: string
+): string {
+  if (!value) return presets[0]?.name ?? fallback;
+  const matched = presets.find((p) => p.value === value);
+  if (matched) return matched.name;
+  return fallback;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@kirby/vcs-core": "*",
         "@kirby/vcs-github": "*",
         "@kirby/worktree-manager": "*",
+        "@mishieck/ink-titled-box": "0.4.2",
         "ink": "^6.8.0",
         "node-pty": "^1.1.0",
         "react": "^19.2.4"
@@ -3495,6 +3496,17 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@mishieck/ink-titled-box": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@mishieck/ink-titled-box/-/ink-titled-box-0.4.2.tgz",
+      "integrity": "sha512-4tRyg2n9dPGY66EEchpjHSs+QL5Wdv8kAjRLg/BnXVimwwIl38sLhgphw8dGCGIK2pFz+owLi4vuQBdOdJivBA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ink": "^6.0.0",
+        "react": "^19.1.0",
+        "typescript": "^5"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -11844,7 +11856,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
       "name": "@kirby/cli",
       "version": "0.0.1",
       "dependencies": {
+        "@inkjs/ui": "^2.0.0",
         "@kirby/logger": "*",
         "@kirby/terminal": "*",
         "@kirby/vcs-azure-devops": "*",
@@ -2566,6 +2567,75 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inkjs/ui": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inkjs/ui/-/ui-2.0.0.tgz",
+      "integrity": "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-spinners": "^3.0.0",
+        "deepmerge": "^4.3.1",
+        "figures": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5"
+      }
+    },
+    "node_modules/@inkjs/ui/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@inkjs/ui/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inkjs/ui/node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inkjs/ui/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -7100,7 +7170,6 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
## Summary

- Top bar removed. Sidebar and main pane gain round, **titled borders** (title rendered *inside* the top border line via `@mishieck/ink-titled-box`).
- Active pane border flips to **cyan**; inactive stays gray. Focus derivation is a pure, unit-tested helper.
- Transient messages now render as a proper top-right **toast stack** (up to 5 stacked, auto-dismiss, variant-colored via `@inkjs/ui` Alert).
- Delete confirmation is now a centered **overlay modal** with a blinking cursor.
- Bottom StatusBar slimmed to a single branch (VCS setup hint); every other surface moved to a purpose-built location.

## Layout & visual hierarchy

- Old top header (Kirby + cwd + StatusBar) is gone.
- Sidebar and main pane share a `<Pane>` component (round border, title embedded in the top line).
- `@mishieck/ink-titled-box@0.4.2` (pinned) handles the title-in-border glyph composition.
- `LAYOUT.PANE_TITLE_ROWS` → 0 now that titles live in the border — downstream (DiffViewer, PTY sizing, sidebar scroll budget) all gain 1 row of content.

## Pane titles

- **Sidebar:** `😸 Kirby`.
- **Main pane (terminal mode):** `🤖 Claude — Fix navigation bug` (agent display name resolved via `AI_PRESETS`; label prefers PR title, falls back to branch). When focused, suffixed with `(ctrl+space to exit)`.
- **Main pane (other modes):** `Files Changed`, `Pull Request`, `New Session`, `Settings`, `Controls`, `Confirm Delete`, etc.

## Toast system

- Top-right stack, 40 cols wide, 2-col gutters. Right-aligned so short toasts hug the edge.
- Variant colors: `info` / `success` / `warning` / `error`.
- 3s auto-dismiss per toast. Max 5 visible; the 6th evicts the oldest.
- Every existing `flashStatus(msg, variant?)` call site works unchanged — `flashStatus` now delegates to `ToastContext.flash`.
- `prError` transitions flash a toast (dedup via React's `Object.is` bail-out — same-string polls don't re-fire).
- `ToastContext` is split into `useToastState` (renderer) and `useToastActions` (stable `{flash, dismiss}`) so pushing toasts doesn't re-render every consumer.
- Timer handles tracked in a `Map` ref, cleared on dismiss / eviction / unmount.

## Delete confirmation modal

- Reusable `<Modal>` component — full-screen absolute wrapper with explicit `width`/`height` from LayoutContext, flex-centers its child. Ink's four-offsets stretch-to-fill is unreliable; this works.
- `<DeleteConfirmModal>` uses it to show `<Alert variant=\"warning\">` + the branch-name confirm input with a blinking cursor.
- Flashes a success toast after the delete resolves.

## Async ops indicator

- New `<AsyncOpsIndicator />` — absolutely-positioned top-right spinner that sits just above the toast stack.
- Label shows what's inflight (comma-joined op names: `sync, rebase`).
- Returns `null` when idle; zero visual weight.

## Bottom StatusBar evacuation

Every transient surface moved out:
- Delete confirm → `DeleteConfirmModal`.
- Branch picker filter echo → the `BranchPicker` pane (was duplicated).
- Transient `statusMessage` → top-right toasts.
- `prError` → error toast.
- Terminal focus hint → pane title.
- Async ops spinner → `AsyncOpsIndicator`.

Only the VCS setup hint remains; the bar renders `null` in the steady state.

## Boy scout cleanups

- Sidebar selection indicator merged with the running-state LED into a single icon column (`◉ ◎ ● ○`) — reclaims 2 chars per row for PR titles.
- Row truncation switched from the hand-rolled `truncate()` util to Ink's native `<Text wrap=\"truncate\">`.
- Focus derivation extracted into `screens/main/focus.ts` (pure, unit-tested) — no more inline \`sidebarFocused\` logic scattered in MainTab.
- `MainContent` router extracted from `MainTab` — MainTab now owns the layout shell only.
- `resolvePresetName` utility shared by `SettingsPanel` and the new pane-title helper.

## Test plan

- [x] `nx typecheck + test + lint cli` — 89 unit tests passing
- [x] `nx e2e cli-e2e` — 29/29 passing (4 integration-only skipped, no \`GH_TOKEN\`)
- [ ] Manual: \`nx serve cli\` — each pane has a round titled border; Tab swaps focus color cyan ↔ gray; terminal mode appends \`(ctrl+space to exit)\` when focused
- [ ] Manual: select a session, press \`d\` — centered delete modal with blinking cursor; Esc cancels; typed-name match → session removed + success toast
- [ ] Manual: break VCS token → red error toast (not a bottom-bar alert); spinner appears top-right during sync/rebase with live label

🤖 Generated with [Claude Code](https://claude.com/claude-code)