### PR TITLE
feat(sidebar): reorder sections - worktrees, drafts, then PRs

### DIFF
--- a/apps/cli/src/components/Sidebar.tsx
+++ b/apps/cli/src/components/Sidebar.tsx
@@ -25,6 +25,7 @@ const LEGEND_LINES = 2; // "passed/failed/pending" + "needs attention/approved"
 // ── Section header detection ────────────────────────────────────
 
 type SectionKey =
+  | 'worktrees'
   | 'pull-requests'
   | 'draft-pull-requests'
   | 'needs-review'
@@ -32,13 +33,14 @@ type SectionKey =
   | 'approved';
 
 function getSectionKey(item: SidebarItem): SectionKey {
-  if (item.kind === 'session') return 'pull-requests';
+  if (item.kind === 'session') return 'worktrees';
   if (item.kind === 'orphan-pr')
     return item.pr.isDraft ? 'draft-pull-requests' : 'pull-requests';
   return item.category;
 }
 
 const SECTION_LABELS: Record<SectionKey, { title: string; color: string }> = {
+  worktrees: { title: 'Worktrees', color: 'cyan' },
   'pull-requests': { title: 'Pull Requests', color: 'blue' },
   'draft-pull-requests': { title: 'Draft Pull Requests', color: 'gray' },
   'needs-review': { title: 'Needs Your Review', color: 'red' },

--- a/apps/cli/src/utils/sidebar-items.spec.ts
+++ b/apps/cli/src/utils/sidebar-items.spec.ts
@@ -67,7 +67,7 @@ describe('buildSidebarItems', () => {
     });
   });
 
-  it('places orphan PRs after sessions, active before draft', () => {
+  it('places orphan PRs after sessions, draft before active', () => {
     const activePr = makePr({ id: 10, isDraft: false });
     const draftPr = makePr({ id: 11, isDraft: true });
 
@@ -82,8 +82,8 @@ describe('buildSidebarItems', () => {
     );
 
     expect(items).toHaveLength(2);
-    expect(items[0]).toEqual({ kind: 'orphan-pr', pr: activePr });
-    expect(items[1]).toEqual({ kind: 'orphan-pr', pr: draftPr });
+    expect(items[0]).toEqual({ kind: 'orphan-pr', pr: draftPr });
+    expect(items[1]).toEqual({ kind: 'orphan-pr', pr: activePr });
   });
 
   it('places review PRs after orphans in category order', () => {

--- a/apps/cli/src/utils/sidebar-items.ts
+++ b/apps/cli/src/utils/sidebar-items.ts
@@ -6,9 +6,9 @@ import { branchToSessionName } from '@kirby/worktree-manager';
  * Build a flat, ordered list of sidebar items from all data sources.
  *
  * Section order:
- * 1. Sessions (sorted by PR id descending, sessions without PRs last)
- * 2. Active orphan PRs (your PRs with no worktree session)
- * 3. Draft orphan PRs
+ * 1. Worktrees/sessions (sorted by PR id descending, sessions without PRs last)
+ * 2. Draft orphan PRs
+ * 3. Active orphan PRs (your PRs with no worktree session)
  * 4. Needs review (others' PRs you need to review)
  * 5. Waiting for author
  * 6. Approved by you
@@ -51,15 +51,15 @@ export function buildSidebarItems(
     items.push({ kind: 'session', session, pr, branch, isMerged, conflictCount });
   }
 
-  // 2. Active orphan PRs
-  const activeOrphanPrs = orphanPrs.filter((pr) => pr.isDraft !== true);
-  for (const pr of activeOrphanPrs) {
+  // 2. Draft orphan PRs
+  const draftOrphanPrs = orphanPrs.filter((pr) => pr.isDraft === true);
+  for (const pr of draftOrphanPrs) {
     items.push({ kind: 'orphan-pr', pr });
   }
 
-  // 3. Draft orphan PRs
-  const draftOrphanPrs = orphanPrs.filter((pr) => pr.isDraft === true);
-  for (const pr of draftOrphanPrs) {
+  // 3. Active orphan PRs
+  const activeOrphanPrs = orphanPrs.filter((pr) => pr.isDraft !== true);
+  for (const pr of activeOrphanPrs) {
     items.push({ kind: 'orphan-pr', pr });
   }
 


### PR DESCRIPTION
## Summary
- Split sessions into their own **Worktrees** section at the top of the sidebar (previously lumped under "Pull Requests")
- Swap orphan PR order so **Draft Pull Requests** appear before active **Pull Requests**
- New section order: Worktrees → Draft Pull Requests → Pull Requests → Needs Your Review → Waiting for Author → Approved by You

## Test plan
- [x] `npx nx test cli` — all 88 tests pass
- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean
- [ ] Manually verify sidebar renders with new section order via `npx nx serve cli`