### PR TITLE
feat(cli): jump to next/prev active session with Shift+Arrow

### DIFF
--- a/apps/cli/src/context/SidebarContext.tsx
+++ b/apps/cli/src/context/SidebarContext.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import type { PullRequestInfo } from '@kirby/vcs-core';
 import { branchToSessionName } from '@kirby/worktree-manager';
 import type { SidebarItem } from '../types.js';
-import { getItemKey, getPrFromItem } from '../types.js';
+import { getItemKey, getPrFromItem, isItemActive } from '../types.js';
 import { buildSidebarItems } from '../utils/sidebar-items.js';
 import { useSessionData } from './SessionContext.js';
 import { useConfig } from './ConfigContext.js';
@@ -21,6 +21,8 @@ export interface SidebarContextValue {
   selectByKey: (key: string) => void;
   /** Move selection by a relative offset (positive = down, negative = up). */
   moveSelection: (offset: number) => void;
+  /** Jump to the next/previous active (running) item. No-op if none found. */
+  moveSelectionToActive: (direction: 1 | -1) => void;
 }
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
@@ -112,6 +114,23 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
     [items, resolvedIndex]
   );
 
+  const moveSelectionToActive = useCallback(
+    (direction: 1 | -1) => {
+      for (
+        let i = resolvedIndex + direction;
+        i >= 0 && i < items.length;
+        i += direction
+      ) {
+        const item = items[i];
+        if (item && isItemActive(item)) {
+          setSelectedKey(getItemKey(item));
+          return;
+        }
+      }
+    },
+    [items, resolvedIndex]
+  );
+
   const value = useMemo<SidebarContextValue>(
     () => ({
       items,
@@ -122,6 +141,7 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
       totalItems,
       selectByKey,
       moveSelection,
+      moveSelectionToActive,
     }),
     [
       items,
@@ -132,6 +152,7 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
       totalItems,
       selectByKey,
       moveSelection,
+      moveSelectionToActive,
     ]
   );
 

--- a/apps/cli/src/keybindings/registry.ts
+++ b/apps/cli/src/keybindings/registry.ts
@@ -79,6 +79,16 @@ export const ACTIONS = [
     context: 'sidebar',
   },
   {
+    id: 'sidebar.jump-next-active',
+    label: 'Jump to next active session',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.jump-prev-active',
+    label: 'Jump to previous active session',
+    context: 'sidebar',
+  },
+  {
     id: 'sidebar.quit',
     label: 'Quit',
     context: 'sidebar',
@@ -327,6 +337,8 @@ export const NORMIE_PRESET: KeybindPreset = {
     // Sidebar
     'sidebar.navigate-down': [{ flags: { downArrow: true } }],
     'sidebar.navigate-up': [{ flags: { upArrow: true } }],
+    'sidebar.jump-next-active': [{ shift: true, flags: { downArrow: true } }],
+    'sidebar.jump-prev-active': [{ shift: true, flags: { upArrow: true } }],
     'sidebar.quit': [{ input: 'q' }],
     'sidebar.checkout-branch': [{ input: 'c' }],
     'sidebar.delete-branch': [
@@ -410,6 +422,8 @@ export const VIM_PRESET: KeybindPreset = {
     // Sidebar
     'sidebar.navigate-down': [{ input: 'j' }, { flags: { downArrow: true } }],
     'sidebar.navigate-up': [{ input: 'k' }, { flags: { upArrow: true } }],
+    'sidebar.jump-next-active': [{ shift: true, flags: { downArrow: true } }],
+    'sidebar.jump-prev-active': [{ shift: true, flags: { upArrow: true } }],
     'sidebar.quit': [{ input: 'q' }],
     'sidebar.checkout-branch': [{ input: 'c' }],
     'sidebar.delete-branch': [{ input: 'x' }],

--- a/apps/cli/src/screens/main/sidebar-input.ts
+++ b/apps/cli/src/screens/main/sidebar-input.ts
@@ -243,6 +243,14 @@ export function handleSidebarInput(
     sidebar.moveSelection(-1);
     return;
   }
+  if (action === 'sidebar.jump-next-active') {
+    sidebar.moveSelectionToActive(1);
+    return;
+  }
+  if (action === 'sidebar.jump-prev-active') {
+    sidebar.moveSelectionToActive(-1);
+    return;
+  }
 
   // Enter
   if (action === 'sidebar.start-session' && selectedItem) {

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -40,6 +40,12 @@ export function getItemKey(item: SidebarItem): string {
   return `review:${item.pr.id}`;
 }
 
+/** Whether this sidebar item represents an active (running) agent session. */
+export function isItemActive(item: SidebarItem): boolean {
+  if (item.kind === 'session') return item.session.running;
+  return item.running === true;
+}
+
 export interface AgentSession {
   name: string;
   running: boolean;


### PR DESCRIPTION
## Summary

- Adds `Shift+↓` / `Shift+↑` in the sidebar to jump to the next/previous **active** (running) session, skipping idle entries
- Works in both Normie and Vim presets; arrow-based binding so vim's existing `K` (kill agent) is untouched
- Active = `session.running` for sessions, `running === true` for orphan/review PR rows

## Implementation

- New `isItemActive()` helper in `apps/cli/src/types.ts`
- New `moveSelectionToActive(direction)` on `SidebarContext` — linear scan from current index, no-op if no active item is found in that direction
- Two new actions (`sidebar.jump-next-active`, `sidebar.jump-prev-active`) registered + bound + wired into `sidebar-input.ts`

## Test plan

- [ ] `npx nx test cli` passes (88 tests green locally)
- [ ] `npx nx serve cli` — start ≥2 worktrees with running agents interleaved among idle ones
- [ ] Press `Shift+↓` from the top — selection jumps to first running session, skipping idle ones
- [ ] Press `Shift+↑` from the bottom — jumps backward to previous running session
- [ ] Press at boundary with no active item ahead — selection stays put
- [ ] Plain `↑`/`↓` still moves one row at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)