### PR TITLE
feat(sidebar): split sessions into worktrees/draft/PR sections

### DIFF
--- a/apps/cli-e2e/src/navigation-jump.test.ts
+++ b/apps/cli-e2e/src/navigation-jump.test.ts
@@ -116,10 +116,9 @@ test.use({
 
 test.when(
   hasGhToken,
-  'selected session stays selected after PR data refresh reorders items',
+  'selected session stays selected when another session moves to Pull Requests',
   async ({ terminal }) => {
     let prNumberA: number | undefined;
-    let prNumberB: number | undefined;
 
     try {
       // 1. Wait for Kirby to render
@@ -127,7 +126,8 @@ test.when(
         terminal.getByText('Kirby', { strict: false })
       ).toBeVisible();
 
-      // 2. Both sessions should appear (no PRs yet — both show session names)
+      // 2. Both sessions appear under "Worktrees" (no PRs yet).
+      //    Order is [A, B] — sessions without PRs preserve input order.
       await expect(
         terminal.getByText(sessionA, { strict: false })
       ).toBeVisible();
@@ -135,11 +135,19 @@ test.when(
         terminal.getByText(sessionB, { strict: false })
       ).toBeVisible();
 
-      // 3. Create PR for branch A. This PR will be indexed by GitHub Search
-      //    within ~30-90 seconds. We need it to appear before proceeding.
+      // 3. Navigate down once to select session B (index 1 within Worktrees)
+      terminal.write('j');
+      await new Promise((r) => setTimeout(r, 500));
+
+      // 4. Verify session B is selected
+      await expect(sidebarLocator(terminal, sessionB).selected()).toBeVisible();
+
+      // 5. Create a PR for branch A. A will move from the Worktrees section
+      //    into the Pull Requests section, producing a reorder. Selection
+      //    (tracked by stable key `session:<name>`) must stay on B.
       prNumberA = createPullRequest(TEST_REPO, branchA, cloneDir);
 
-      // 4. Trigger PR refresh via 'r' periodically. Also poll via config (5s).
+      // 6. Trigger PR refresh via 'r' periodically. Also poll via config (5s).
       //    Wait up to 90s for the search API to index the new PR.
       const refreshTimerA = setInterval(() => terminal.write('r'), 10_000);
       terminal.write('r');
@@ -152,57 +160,23 @@ test.when(
         clearInterval(refreshTimerA);
       }
 
-      // 5. Now the sidebar order (sorted by PR ID desc for sessions):
-      //      index 0: session A (has PR #prNumberA) — sorted first
-      //      index 1: session B (no PR) — sorted last
-      //    SidebarContext.selectedIndex = 0 → A is selected.
-
-      // 6. Navigate down once to select session B
-      terminal.write('j');
-      await new Promise((r) => setTimeout(r, 500));
-
-      // 7. Verify session B is selected
-      await expect(sidebarLocator(terminal, sessionB).selected()).toBeVisible();
-
-      // 8. Create a PR for branch B — its ID will be higher than A's,
-      //    so after refresh it sorts ABOVE A.
-      prNumberB = createPullRequest(TEST_REPO, branchB, cloneDir);
-
-      // 9. Wait for B's PR badge to appear
-      const refreshTimerB = setInterval(() => terminal.write('r'), 10_000);
-      terminal.write('r');
-
-      try {
-        await expect(
-          terminal.getByText(`#${prNumberB}`, { strict: false })
-        ).toBeVisible({ timeout: 90_000 });
-      } finally {
-        clearInterval(refreshTimerB);
-      }
-
-      // 10. After refresh the sort order flipped:
-      //       index 0: session B (PR #prNumberB, higher) — now first
-      //       index 1: session A (PR #prNumberA, lower)  — now second
-      //
-      //     BUG: SidebarContext.selectedIndex is still 1 (where B used to be),
-      //     but index 1 now points to session A. The selection jumped.
+      // 7. After refresh:
+      //      Worktrees     (1): B   ← still selected
+      //      Pull Requests (1): A   (moved here because it now has a PR)
 
       // Wait for React to settle
       await new Promise((r) => setTimeout(r, 1_000));
 
-      // Assert: selection should still be on session B's PR title
-      await expect(
-        sidebarLocator(terminal, `e2e: ${branchB}`).selected()
-      ).toBeVisible();
+      // Assert: selection should still be on session B
+      await expect(sidebarLocator(terminal, sessionB).selected()).toBeVisible();
 
-      // Assert: selection should NOT be on session A
+      // Assert: selection should NOT be on session A's PR row
       expect(
         sidebarLocator(terminal, `e2e: ${branchA}`).selected()
       ).not.toBeVisible();
     } finally {
       // Cleanup GitHub resources (best-effort)
       if (prNumberA) closePullRequest(TEST_REPO, prNumberA);
-      if (prNumberB) closePullRequest(TEST_REPO, prNumberB);
       deleteRemoteBranch(TEST_REPO, branchA);
       deleteRemoteBranch(TEST_REPO, branchB);
     }

--- a/apps/cli/src/components/Sidebar.tsx
+++ b/apps/cli/src/components/Sidebar.tsx
@@ -33,7 +33,10 @@ type SectionKey =
   | 'approved';
 
 function getSectionKey(item: SidebarItem): SectionKey {
-  if (item.kind === 'session') return 'worktrees';
+  if (item.kind === 'session') {
+    if (!item.pr) return 'worktrees';
+    return item.pr.isDraft ? 'draft-pull-requests' : 'pull-requests';
+  }
   if (item.kind === 'orphan-pr')
     return item.pr.isDraft ? 'draft-pull-requests' : 'pull-requests';
   return item.category;

--- a/apps/cli/src/utils/sidebar-items.spec.ts
+++ b/apps/cli/src/utils/sidebar-items.spec.ts
@@ -24,7 +24,7 @@ const emptyReviews: CategorizedReviews = {
 };
 
 describe('buildSidebarItems', () => {
-  it('returns sessions first with branch/PR/merge/conflict info', () => {
+  it('emits no-PR sessions before PR-backed sessions with branch/PR/merge/conflict info', () => {
     const sessions: AgentSession[] = [
       { name: 'feature-foo', running: true },
       { name: 'feature-bar', running: false },
@@ -51,23 +51,58 @@ describe('buildSidebarItems', () => {
     expect(items).toHaveLength(2);
     expect(items[0]).toEqual({
       kind: 'session',
-      session: sessions[0],
-      pr,
-      branch: 'feature/foo',
-      isMerged: false,
-      conflictCount: 3,
-    });
-    expect(items[1]).toEqual({
-      kind: 'session',
       session: sessions[1],
       pr: undefined,
       branch: 'feature/bar',
       isMerged: true,
       conflictCount: undefined,
     });
+    expect(items[1]).toEqual({
+      kind: 'session',
+      session: sessions[0],
+      pr,
+      branch: 'feature/foo',
+      isMerged: false,
+      conflictCount: 3,
+    });
   });
 
-  it('places orphan PRs after sessions, draft before active', () => {
+  it('splits PR-backed sessions into draft and active buckets', () => {
+    const sessions: AgentSession[] = [
+      { name: 'feature-active', running: true },
+      { name: 'feature-draft', running: true },
+      { name: 'feature-local', running: false },
+    ];
+    const activePr = makePr({ id: 40, isDraft: false });
+    const draftPr = makePr({ id: 41, isDraft: true });
+    const sessionBranchMap = new Map([
+      ['feature-active', 'feature/active'],
+      ['feature-draft', 'feature/draft'],
+      ['feature-local', 'feature/local'],
+    ]);
+    const sessionPrMap = new Map([
+      ['feature-active', activePr],
+      ['feature-draft', draftPr],
+    ]);
+
+    const items = buildSidebarItems(
+      sessions,
+      [],
+      emptyReviews,
+      sessionBranchMap,
+      sessionPrMap,
+      new Set(),
+      new Map()
+    );
+
+    expect(items.map((i) => (i.kind === 'session' ? i.session.name : i.kind))).toEqual([
+      'feature-local',
+      'feature-draft',
+      'feature-active',
+    ]);
+  });
+
+  it('places draft orphan PRs before active orphan PRs', () => {
     const activePr = makePr({ id: 10, isDraft: false });
     const draftPr = makePr({ id: 11, isDraft: true });
 

--- a/apps/cli/src/utils/sidebar-items.ts
+++ b/apps/cli/src/utils/sidebar-items.ts
@@ -6,9 +6,9 @@ import { branchToSessionName } from '@kirby/worktree-manager';
  * Build a flat, ordered list of sidebar items from all data sources.
  *
  * Section order:
- * 1. Worktrees/sessions (sorted by PR id descending, sessions without PRs last)
- * 2. Draft orphan PRs
- * 3. Active orphan PRs (your PRs with no worktree session)
+ * 1. Worktrees — sessions with no PR
+ * 2. Draft Pull Requests — sessions with a draft PR, then draft orphan PRs
+ * 3. Pull Requests — sessions with an active PR, then active orphan PRs
  * 4. Needs review (others' PRs you need to review)
  * 5. Waiting for author
  * 6. Approved by you
@@ -41,25 +41,42 @@ export function buildSidebarItems(
   // Build a quick lookup: session name → AgentSession for review-pr running status
   const sessionByName = new Map(sortedSessions.map((s) => [s.name, s]));
 
-  // 1. Sessions (exclude those whose branch belongs to a review PR)
+  // Bucket sessions by PR status so each section can be emitted in order.
+  const noPrSessions: SidebarItem[] = [];
+  const draftPrSessions: SidebarItem[] = [];
+  const activePrSessions: SidebarItem[] = [];
+
   for (const session of sortedSessions) {
     const branch = sessionBranchMap.get(session.name);
     if (branch && reviewBranches.has(branch)) continue;
     const pr = sessionPrMap.get(session.name);
     const isMerged = branch ? mergedBranches.has(branch) : false;
     const conflictCount = branch ? conflictCounts.get(branch) : undefined;
-    items.push({ kind: 'session', session, pr, branch, isMerged, conflictCount });
+    const item: SidebarItem = {
+      kind: 'session',
+      session,
+      pr,
+      branch,
+      isMerged,
+      conflictCount,
+    };
+    if (!pr) noPrSessions.push(item);
+    else if (pr.isDraft) draftPrSessions.push(item);
+    else activePrSessions.push(item);
   }
 
-  // 2. Draft orphan PRs
-  const draftOrphanPrs = orphanPrs.filter((pr) => pr.isDraft === true);
-  for (const pr of draftOrphanPrs) {
+  // 1. Worktrees (sessions with no PR)
+  items.push(...noPrSessions);
+
+  // 2. Draft Pull Requests — session-backed first, then orphans
+  items.push(...draftPrSessions);
+  for (const pr of orphanPrs.filter((p) => p.isDraft === true)) {
     items.push({ kind: 'orphan-pr', pr });
   }
 
-  // 3. Active orphan PRs
-  const activeOrphanPrs = orphanPrs.filter((pr) => pr.isDraft !== true);
-  for (const pr of activeOrphanPrs) {
+  // 3. Pull Requests — session-backed first, then orphans
+  items.push(...activePrSessions);
+  for (const pr of orphanPrs.filter((p) => p.isDraft !== true)) {
     items.push({ kind: 'orphan-pr', pr });
   }
 


### PR DESCRIPTION
## Summary
- Sidebar now emits three distinct top sections: **Worktrees** (sessions with no PR), **Draft Pull Requests** (draft-PR sessions + draft orphans), and **Pull Requests** (active-PR sessions + active orphans).
- Review sections (Needs Your Review / Waiting for Author / Approved by You) are unchanged.
- `getSectionKey` in `Sidebar.tsx` now routes session items by PR state; `buildSidebarItems` buckets sessions into three groups before emitting, with session-backed items before orphan PRs inside each PR-backed section.

## Test plan
- [x] `npx nx test cli` — 89 tests pass (includes updated + new `sidebar-items.spec.ts` cases)
- [x] `npx tsc --noEmit -p apps/cli/tsconfig.app.json` — clean
- [ ] Manual QA: open the TUI and confirm headers render in order `Worktrees` → `Draft Pull Requests` → `Pull Requests` → review sections, with counts accurate and empty sections hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)