### PR TITLE
feat(cli): add ? shortcut to toggle sidebar hints

### DIFF
--- a/apps/cli-e2e/src/keybindings.test.ts
+++ b/apps/cli-e2e/src/keybindings.test.ts
@@ -204,6 +204,39 @@ test.describe('Keybindings — Per-Binding Rebind', () => {
   });
 });
 
+// ── Hint Toggle ────────────────────────────────────────────────────
+
+test.describe('Keybindings — Hint Toggle', () => {
+  // Default 30 rows leaves the last hint right at the bottom border; use
+  // a taller terminal so the full expanded list is unambiguously visible.
+  test.use({ rows: 40 });
+
+  test('? collapses hints to single "show hints" row and restores them', async ({
+    kirby,
+  }) => {
+    await expect(kirby.term.getByText('Kirby').first()).toBeVisible();
+
+    // Default state: full hint list rendered, including the toggle itself.
+    await expect(kirby.term.getByText('hide hints').first()).toBeVisible();
+    await expect(kirby.term.getByText('quit').first()).toBeVisible();
+
+    // Collapse.
+    await kirby.term.type('?');
+    await expect(kirby.term.getByText('show hints').first()).toBeVisible();
+    await expect(kirby.term.getByText('quit').first()).not.toBeVisible({
+      timeout: 3_000,
+    });
+    await expect(kirby.term.getByText('hide hints').first()).not.toBeVisible({
+      timeout: 3_000,
+    });
+
+    // Restore.
+    await kirby.term.type('?');
+    await expect(kirby.term.getByText('hide hints').first()).toBeVisible();
+    await expect(kirby.term.getByText('quit').first()).toBeVisible();
+  });
+});
+
 // ── Modifier key display ───────────────────────────────────────────
 
 test.describe('Keybindings — Modifier key display', () => {

--- a/apps/cli/src/components/Sidebar.tsx
+++ b/apps/cli/src/components/Sidebar.tsx
@@ -209,6 +209,7 @@ export interface SidebarProps {
   termRows: number;
   focused: boolean;
   conflictsLoading?: boolean;
+  hintsHidden?: boolean;
 }
 
 export const Sidebar = memo(function Sidebar({
@@ -217,6 +218,7 @@ export const Sidebar = memo(function Sidebar({
   sidebarWidth,
   termRows,
   focused,
+  hintsHidden = false,
 }: SidebarProps) {
   const { vcsConfigured } = useConfig();
   const keybinds = useKeybinds();
@@ -224,6 +226,12 @@ export const Sidebar = memo(function Sidebar({
   // Build dynamic keybind hints from the active preset
   const sidebarHints = useMemo(() => {
     const hints = keybinds.getHints('sidebar');
+
+    if (hintsHidden) {
+      const toggle = hints.find((h) => h.actionId === 'sidebar.toggle-hints');
+      return toggle ? [{ ...toggle, label: 'show hints' }] : [];
+    }
+
     const filtered = vcsConfigured ? hints : hints.filter((h) => !h.vcsOnly);
 
     // Combine navigate-down + navigate-up into a single "j/k navigate" hint
@@ -243,7 +251,7 @@ export const Sidebar = memo(function Sidebar({
       ];
     }
     return filtered;
-  }, [keybinds, vcsConfigured]);
+  }, [keybinds, vcsConfigured, hintsHidden]);
 
   const keybindLineCount = sidebarHints.length;
 
@@ -305,7 +313,7 @@ export const Sidebar = memo(function Sidebar({
       SIDEBAR_CHROME_ROWS +
       1 +
       keybindLineCount +
-      (vcsConfigured ? 1 + LEGEND_LINES : 0);
+      (vcsConfigured && !hintsHidden ? 1 + LEGEND_LINES : 0);
     const availableLines = termRows - chromeLines;
     const totalHeight = rowHeights.reduce((a, b) => a + b, 0);
 
@@ -374,6 +382,7 @@ export const Sidebar = memo(function Sidebar({
     termRows,
     vcsConfigured,
     keybindLineCount,
+    hintsHidden,
   ]);
 
   const renderRow = (row: RenderRow) => {
@@ -445,7 +454,7 @@ export const Sidebar = memo(function Sidebar({
         </>
       }
       legend={
-        vcsConfigured ? (
+        vcsConfigured && !hintsHidden ? (
           <>
             <Text dimColor>🔧✅ passed 🔧🔥 failed 🔧⏳ pending</Text>
             <Text dimColor>🔔 needs attention ⭐ fully approved</Text>

--- a/apps/cli/src/keybindings/registry.ts
+++ b/apps/cli/src/keybindings/registry.ts
@@ -173,6 +173,13 @@ export const ACTIONS = [
     label: 'Focus terminal',
     context: 'sidebar',
   },
+  {
+    id: 'sidebar.toggle-hints',
+    label: 'Toggle hint visibility',
+    context: 'sidebar',
+    hintLabel: 'hide hints',
+    showInHints: true,
+  },
 
   // ── Settings ──
   {
@@ -354,6 +361,7 @@ export const NORMIE_PRESET: KeybindPreset = {
     'sidebar.view-diff': [{ input: 'd' }],
     'sidebar.start-session': [{ flags: { return: true } }],
     'sidebar.focus-terminal': [{ flags: { tab: true } }],
+    'sidebar.toggle-hints': [{ input: '?' }],
 
     // Settings
     'settings.navigate-down': [{ flags: { downArrow: true } }],
@@ -436,6 +444,7 @@ export const VIM_PRESET: KeybindPreset = {
     'sidebar.view-diff': [{ input: 'd' }],
     'sidebar.start-session': [{ flags: { return: true } }],
     'sidebar.focus-terminal': [{ flags: { tab: true } }],
+    'sidebar.toggle-hints': [{ input: '?' }],
 
     // Settings (same as normie — transient modal)
     'settings.navigate-down': [{ input: 'j' }, { flags: { downArrow: true } }],

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from 'react';
 import { useInput } from 'ink';
 import { Sidebar } from '../../components/Sidebar.js';
 import { Pane } from '../../components/Pane.js';
@@ -45,6 +46,9 @@ export function MainTab({
     sidebar.selectedItem,
     sidebar.sessionNameForTerminal
   );
+
+  const [hintsHidden, setHintsHidden] = useState(false);
+  const toggleHints = useCallback(() => setHintsHidden((v) => !v), []);
 
   // ── Input handling (modals + sidebar) ──────────────────────────
   useInput((input, key) => {
@@ -121,6 +125,7 @@ export function MainTab({
       terminal,
       pane,
       keybinds,
+      toggleHints,
       exit,
     });
   });
@@ -182,6 +187,7 @@ export function MainTab({
           sidebarWidth={layout.sidebarWidth}
           termRows={layout.termRows}
           focused={sidebarFocused}
+          hintsHidden={hintsHidden}
         />
       )}
       <Pane focused={mainFocused} title={paneTitle} flexGrow={1}>

--- a/apps/cli/src/screens/main/input-types.ts
+++ b/apps/cli/src/screens/main/input-types.ts
@@ -90,5 +90,6 @@ export interface SidebarInputCtx {
   terminal: TerminalLayout;
   pane: PaneModeValue;
   keybinds: KeybindContextValue;
+  toggleHints: () => void;
   exit: () => void;
 }

--- a/apps/cli/src/screens/main/sidebar-input.ts
+++ b/apps/cli/src/screens/main/sidebar-input.ts
@@ -22,6 +22,12 @@ export function handleSidebarInput(
 
   const action = ctx.keybinds.resolve(input, key, 'sidebar');
 
+  // Toggle hint visibility
+  if (action === 'sidebar.toggle-hints') {
+    ctx.toggleHints();
+    return;
+  }
+
   // Tab focus toggle
   if (action === 'sidebar.focus-terminal') {
     if (ctx.nav.focus === 'sidebar' && sidebar.sessionNameForTerminal) {


### PR DESCRIPTION
## Summary

- Adds a `?` keybinding in the sidebar that collapses the hint footer to a single `?  show hints` row, reclaiming the space (and the VCS legend) for more PR/session items.
- Press `?` again to restore the full hint list and legend.
- State is session-local — if you want it to persist across launches, we can promote it to `AppConfig` in a follow-up.

Registered as `sidebar.toggle-hints` in both Normie and Vim presets, so it also shows up in the Controls panel and is user-rebindable.

## Test plan

- [x] `npx nx typecheck cli` clean
- [x] `npx nx test cli` — 89 tests pass (resolver/registry unchanged)
- [x] `npx nx e2e cli-e2e` — new `Keybindings — Hint Toggle` test covers default → collapsed → restored; all 16 keybindings tests pass
- [x] Manual: `npx nx serve cli` in a VCS-configured repo, verify `?` toggles hints and legend, and that extra PR rows become visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)