### PR TITLE
feat(cli): activity indicator + idle toast + Ctrl+Space queue jump

### DIFF
--- a/apps/cli-e2e/src/activity-queue.test.ts
+++ b/apps/cli-e2e/src/activity-queue.test.ts
@@ -1,0 +1,96 @@
+import { test, expect, fakeAgentCommand } from './fixtures/kirby.js';
+import { sidebarLocator } from './setup/sidebar.js';
+import { createSession } from './setup/sessions.js';
+
+// Both sessions run the same fake-agent (aiCommand is global). We rely
+// on the active→idle edge being detected after the 4s burst plus the
+// 2s idle window, while we focus into the second session and let the
+// first one transition behind us.
+const aiCommand = fakeAgentCommand({ bursts: 1, burstMs: 4_000 });
+
+test.describe('Activity queue (Ctrl+Space, setting on)', () => {
+  test.use({
+    kirbyConfig: {
+      aiCommand,
+      autoHideSidebar: false,
+      keybindPreset: 'vim',
+    },
+  });
+
+  test('jumps to a queued idle session', async ({ kirby }) => {
+    // Session A: bursts then goes idle.
+    await createSession(kirby.term, 'busy');
+    await kirby.term.press('Tab');
+    await expect(
+      kirby.term.getByText('kirby-fake-agent-ready').first()
+    ).toBeVisible({ timeout: 10_000 });
+    await kirby.term.write('\x00');
+
+    // Session B: created next, focus moves here. We Tab into it so its
+    // PTY starts (otherwise Ctrl+Space wouldn't intercept — escape only
+    // works from a terminal-focused session).
+    await createSession(kirby.term, 'second');
+    await kirby.term.press('Tab');
+    await expect(kirby.term.getByText(/Agent.*second/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Wait for the watcher to detect "busy" going idle and enqueue it.
+    // The toast is the user-visible signal that the queue has an entry.
+    await expect(kirby.term.getByText('busy is idle')).toBeVisible({
+      timeout: 12_000,
+    });
+
+    // Ctrl+Space from inside `second`'s terminal should pop the queue
+    // and select `busy` (instead of returning to the sidebar).
+    await kirby.term.write('\x00');
+
+    // Sidebar selection moved to `busy` (◉ ring icon in front of name).
+    await expect(
+      sidebarLocator(kirby.term.page, 'busy').selected()
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+test.describe('Activity queue (Ctrl+Space, setting off)', () => {
+  test.use({
+    kirbyConfig: {
+      aiCommand,
+      autoHideSidebar: false,
+      jumpToInactiveOnEscape: false,
+      keybindPreset: 'vim',
+    },
+  });
+
+  test('falls back to sidebar focus when setting is off', async ({ kirby }) => {
+    await createSession(kirby.term, 'busy');
+    await kirby.term.press('Tab');
+    await expect(
+      kirby.term.getByText('kirby-fake-agent-ready').first()
+    ).toBeVisible({ timeout: 10_000 });
+    await kirby.term.write('\x00');
+
+    await createSession(kirby.term, 'second');
+    await kirby.term.press('Tab');
+    await expect(kirby.term.getByText(/Agent.*second/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Toast still fires (toast is independent of the jump setting), so
+    // we can use it as a synchronization point that the model has
+    // observed busy → idle.
+    await expect(kirby.term.getByText('busy is idle')).toBeVisible({
+      timeout: 12_000,
+    });
+
+    await kirby.term.write('\x00');
+
+    // With the setting off, Ctrl+Space should restore the original
+    // behavior: focus the sidebar. Focus signal we can observe is that
+    // the main pane no longer carries the "(ctrl+space to exit)" hint,
+    // which getPaneTitle only appends when terminal-focused.
+    await expect(kirby.term.getByText(/ctrl\+space to exit/)).not.toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});

--- a/apps/cli-e2e/src/activity-queue.test.ts
+++ b/apps/cli-e2e/src/activity-queue.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, fakeAgentCommand } from './fixtures/kirby.js';
 import { sidebarLocator } from './setup/sidebar.js';
-import { createSession } from './setup/sessions.js';
+import { createSession, waitForSidebarFocused } from './setup/sessions.js';
 
 // Both sessions run the same fake-agent (aiCommand is global). We rely
 // on the active→idle edge being detected after the 4s burst plus the
@@ -25,6 +25,7 @@ test.describe('Activity queue (Ctrl+Space, setting on)', () => {
       kirby.term.getByText('kirby-fake-agent-ready').first()
     ).toBeVisible({ timeout: 10_000 });
     await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
 
     // Session B: created next, focus moves here. We Tab into it so its
     // PTY starts (otherwise Ctrl+Space wouldn't intercept — escape only
@@ -69,6 +70,7 @@ test.describe('Activity queue (Ctrl+Space, setting off)', () => {
       kirby.term.getByText('kirby-fake-agent-ready').first()
     ).toBeVisible({ timeout: 10_000 });
     await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
 
     await createSession(kirby.term, 'second');
     await kirby.term.press('Tab');

--- a/apps/cli-e2e/src/activity-spinner.test.ts
+++ b/apps/cli-e2e/src/activity-spinner.test.ts
@@ -1,0 +1,47 @@
+import { test, expect, fakeAgentCommand } from './fixtures/kirby.js';
+import { createSession } from './setup/sessions.js';
+
+// `autoHideSidebar: false` keeps the sidebar visible while the terminal
+// is focused, so we can assert against a row that isn't currently
+// selected. Selected rows suppress the spinner by design (the user can
+// see the activity live in the terminal pane).
+test.use({
+  kirbyConfig: {
+    aiCommand: fakeAgentCommand({ bursts: 1, burstMs: 12_000 }),
+    autoHideSidebar: false,
+    keybindPreset: 'vim',
+  },
+});
+
+const SPINNER_GLYPH_CLASS = /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/;
+
+test.describe('Activity spinner', () => {
+  test('appears in sidebar row of a non-selected, bursting session', async ({
+    kirby,
+  }) => {
+    // 1. Create session A (the busy one). PTY is not yet started.
+    await createSession(kirby.term, 'busy');
+    // 2. Tab into A → PTY spawns, fake-agent begins its burst.
+    await kirby.term.press('Tab');
+    await expect(
+      kirby.term.getByText('kirby-fake-agent-ready').first()
+    ).toBeVisible({ timeout: 10_000 });
+    // 3. Ctrl+Space escapes back to the sidebar.
+    await kirby.term.write('\x00');
+
+    // 4. Create session B (silent). Selection moves to B; A is no longer
+    //    selected, so the activity indicator on A is now eligible to
+    //    render.
+    await createSession(kirby.term, 'idle');
+
+    // 5. A is still bursting (12s headroom). Assert its row picks up a
+    //    spinner glyph. The watcher polls at 250ms; allow generous slack
+    //    so a slow CI runner doesn't flake.
+    const busyRow = kirby.term.page.locator('.term-row', {
+      hasText: /[●○].*busy/,
+    });
+    await expect(busyRow).toContainText(SPINNER_GLYPH_CLASS, {
+      timeout: 8_000,
+    });
+  });
+});

--- a/apps/cli-e2e/src/activity-spinner.test.ts
+++ b/apps/cli-e2e/src/activity-spinner.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, fakeAgentCommand } from './fixtures/kirby.js';
-import { createSession } from './setup/sessions.js';
+import { createSession, waitForSidebarFocused } from './setup/sessions.js';
 
 // `autoHideSidebar: false` keeps the sidebar visible while the terminal
 // is focused, so we can assert against a row that isn't currently
@@ -26,8 +26,11 @@ test.describe('Activity spinner', () => {
     await expect(
       kirby.term.getByText('kirby-fake-agent-ready').first()
     ).toBeVisible({ timeout: 10_000 });
-    // 3. Ctrl+Space escapes back to the sidebar.
+    // 3. Ctrl+Space escapes back to the sidebar. Wait for the focus
+    //    change to actually land before continuing — see
+    //    waitForSidebarFocused for why.
     await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
 
     // 4. Create session B (silent). Selection moves to B; A is no longer
     //    selected, so the activity indicator on A is now eligible to

--- a/apps/cli-e2e/src/activity-toast.test.ts
+++ b/apps/cli-e2e/src/activity-toast.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, fakeAgentCommand } from './fixtures/kirby.js';
-import { createSession } from './setup/sessions.js';
+import { createSession, waitForSidebarFocused } from './setup/sessions.js';
 
 test.use({
   kirbyConfig: {
@@ -25,6 +25,7 @@ test.describe('Activity toast', () => {
       kirby.term.getByText('kirby-fake-agent-ready').first()
     ).toBeVisible({ timeout: 10_000 });
     await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
 
     // 2. Create a second session ("idle") so busy is no longer the
     //    currently-viewed session — that suppression rule is what we're

--- a/apps/cli-e2e/src/activity-toast.test.ts
+++ b/apps/cli-e2e/src/activity-toast.test.ts
@@ -1,0 +1,41 @@
+import { test, expect, fakeAgentCommand } from './fixtures/kirby.js';
+import { createSession } from './setup/sessions.js';
+
+test.use({
+  kirbyConfig: {
+    // 4s of bursts comfortably exceeds MIN_ACTIVE_MS=300, so the
+    // session becomes flash-eligible. After the burst ends, the watcher
+    // detects the active→idle transition (~ACTIVITY_IDLE_MS=2s later)
+    // and fires the info toast.
+    aiCommand: fakeAgentCommand({ bursts: 1, burstMs: 4_000 }),
+    autoHideSidebar: false,
+    keybindPreset: 'vim',
+  },
+});
+
+test.describe('Activity toast', () => {
+  test('idle toast fires for a non-viewed session that goes idle', async ({
+    kirby,
+  }) => {
+    // 1. Create the session that will burst then go idle ("busy"), and
+    //    Tab into it so the PTY actually starts.
+    await createSession(kirby.term, 'busy');
+    await kirby.term.press('Tab');
+    await expect(
+      kirby.term.getByText('kirby-fake-agent-ready').first()
+    ).toBeVisible({ timeout: 10_000 });
+    await kirby.term.write('\x00');
+
+    // 2. Create a second session ("idle") so busy is no longer the
+    //    currently-viewed session — that suppression rule is what we're
+    //    explicitly side-stepping here.
+    await createSession(kirby.term, 'idle');
+
+    // 3. Wait for busy's burst to end and the watcher to detect the
+    //    active→idle edge. Toast text comes from
+    //    `${name} is idle` in useInactiveAlertWatcher.ts.
+    await expect(kirby.term.getByText('busy is idle')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/apps/cli-e2e/src/fixtures/fake-agent.mjs
+++ b/apps/cli-e2e/src/fixtures/fake-agent.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+//
+// fake-agent.mjs
+//
+// Scriptable stand-in for an AI agent (Claude/Codex/etc.) that Kirby
+// can spawn through its normal `aiCommand` path. Used by e2e tests so
+// session activity timing — burst → idle → maybe-burst → exit — is
+// deterministic without depending on a real agent or wall-clock luck.
+//
+// Default behavior (`node fake-agent.mjs`) prints the banner, emits one
+// short burst, and exits. Flags below configure other shapes.
+//
+// Manual repros for each canned scenario:
+//
+//   # (i) emit then idle then exit
+//   node apps/cli-e2e/src/fixtures/fake-agent.mjs --bursts=1 --burst-ms=500
+//
+//   # (ii) silent forever (Ctrl+C to stop)
+//   node apps/cli-e2e/src/fixtures/fake-agent.mjs --silent
+//
+//   # (iii) periodic bursts forever
+//   node apps/cli-e2e/src/fixtures/fake-agent.mjs --bursts=inf --burst-ms=500 --idle-ms=3000
+//
+//   # (iv) echo stdin after a delay (run in a real TTY)
+//   node apps/cli-e2e/src/fixtures/fake-agent.mjs --silent --echo --echo-delay-ms=200
+//
+//   # (v) exit after N seconds
+//   node apps/cli-e2e/src/fixtures/fake-agent.mjs --silent --exit-after-ms=2000
+//
+// Flags:
+//   --banner=<str>         initial line (default "kirby-fake-agent-ready")
+//   --bursts=<n|inf>       number of bursts before going silent (default 1)
+//   --burst-ms=<n>         duration of each burst (default 500)
+//   --burst-bytes=<n>      bytes emitted per 100ms tick within a burst (default 64)
+//   --idle-ms=<n>          silence between bursts (default 0 = continuous)
+//   --silent               banner then sleep forever; overrides --bursts
+//   --echo                 echo stdin back after --echo-delay-ms
+//   --echo-delay-ms=<n>    echo delay (default 0)
+//   --exit-after-ms=<n>    self-exit after N ms (default never)
+
+const args = parseArgs(process.argv.slice(2));
+const banner = args.banner ?? 'kirby-fake-agent-ready';
+const bursts = args.silent ? 0 : parseBursts(args.bursts ?? '1');
+const burstMs = parseInt(args['burst-ms'] ?? '500', 10);
+const burstBytes = parseInt(args['burst-bytes'] ?? '64', 10);
+const idleMs = parseInt(args['idle-ms'] ?? '0', 10);
+const echo = !!args.echo;
+const echoDelayMs = parseInt(args['echo-delay-ms'] ?? '0', 10);
+const exitAfterMs = args['exit-after-ms']
+  ? parseInt(args['exit-after-ms'], 10)
+  : null;
+
+const timers = new Set();
+const setTimer = (fn, ms) => {
+  const id = setTimeout(() => {
+    timers.delete(id);
+    fn();
+  }, ms);
+  timers.add(id);
+  return id;
+};
+const setRepeating = (fn, ms) => {
+  const id = setInterval(fn, ms);
+  timers.add(id);
+  return id;
+};
+const clearAllTimers = () => {
+  for (const id of timers) {
+    clearTimeout(id);
+    clearInterval(id);
+  }
+  timers.clear();
+};
+
+function shutdown() {
+  clearAllTimers();
+  try {
+    process.stdout.end();
+  } catch {
+    /* best effort */
+  }
+  process.exit(0);
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+process.on('SIGHUP', shutdown);
+
+process.stdout.write(banner + '\n');
+
+if (echo) {
+  if (process.stdin.isTTY) process.stdin.setRawMode(true);
+  process.stdin.on('data', (chunk) => {
+    setTimer(() => process.stdout.write(chunk), echoDelayMs);
+  });
+  process.stdin.resume();
+}
+
+if (exitAfterMs != null) setTimer(shutdown, exitAfterMs);
+
+runBursts();
+
+// ── helpers ────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const out = {};
+  for (const a of argv) {
+    if (!a.startsWith('--')) continue;
+    const eq = a.indexOf('=');
+    if (eq === -1) out[a.slice(2)] = true;
+    else out[a.slice(2, eq)] = a.slice(eq + 1);
+  }
+  return out;
+}
+
+function parseBursts(v) {
+  if (v === 'inf' || v === 'infinite') return Infinity;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : 1;
+}
+
+function runBursts() {
+  if (bursts === 0) return;
+  let remaining = bursts;
+  const chunk = '.'.repeat(burstBytes);
+  const startBurst = () => {
+    const ticker = setRepeating(() => process.stdout.write(chunk), 100);
+    setTimer(() => {
+      clearInterval(ticker);
+      timers.delete(ticker);
+      process.stdout.write('\n');
+      remaining--;
+      if (remaining <= 0) {
+        // No more bursts. Stay alive so the PTY doesn't close until the
+        // test or signal handler asks us to exit (matches a real agent
+        // sitting at a prompt).
+        if (!echo && exitAfterMs == null) keepAlive();
+        return;
+      }
+      setTimer(startBurst, idleMs);
+    }, burstMs);
+  };
+  startBurst();
+}
+
+function keepAlive() {
+  // Cheap way to prevent Node's event loop from emptying out.
+  setRepeating(() => undefined, 60_000);
+}

--- a/apps/cli-e2e/src/fixtures/kirby.ts
+++ b/apps/cli-e2e/src/fixtures/kirby.ts
@@ -9,7 +9,47 @@ import { mkdtempSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { cleanupTestRepo, createTestRepo } from '../setup/git-repo.js';
+
+// ── fakeAgentCommand ───────────────────────────────────────────────
+
+export interface FakeAgentOpts {
+  banner?: string;
+  bursts?: number | 'inf';
+  burstMs?: number;
+  burstBytes?: number;
+  idleMs?: number;
+  silent?: boolean;
+  echo?: boolean;
+  echoDelayMs?: number;
+  exitAfterMs?: number;
+}
+
+const FAKE_AGENT_PATH = fileURLToPath(
+  new URL('./fake-agent.mjs', import.meta.url)
+);
+
+/**
+ * Returns a shell command (suitable for `kirbyConfig.aiCommand`) that
+ * spawns the fake-agent harness with the given scenario. See
+ * `fake-agent.mjs` for the full flag reference.
+ */
+export function fakeAgentCommand(opts: FakeAgentOpts = {}): string {
+  const flags: string[] = [];
+  if (opts.banner != null) flags.push(`--banner=${opts.banner}`);
+  if (opts.bursts != null) flags.push(`--bursts=${opts.bursts}`);
+  if (opts.burstMs != null) flags.push(`--burst-ms=${opts.burstMs}`);
+  if (opts.burstBytes != null) flags.push(`--burst-bytes=${opts.burstBytes}`);
+  if (opts.idleMs != null) flags.push(`--idle-ms=${opts.idleMs}`);
+  if (opts.silent) flags.push('--silent');
+  if (opts.echo) flags.push('--echo');
+  if (opts.echoDelayMs != null)
+    flags.push(`--echo-delay-ms=${opts.echoDelayMs}`);
+  if (opts.exitAfterMs != null)
+    flags.push(`--exit-after-ms=${opts.exitAfterMs}`);
+  return ['node', FAKE_AGENT_PATH, ...flags].join(' ');
+}
 
 export interface KirbyOptions {
   kirbyConfig?: Record<string, unknown>;

--- a/apps/cli-e2e/src/setup/sessions.ts
+++ b/apps/cli-e2e/src/setup/sessions.ts
@@ -11,7 +11,7 @@ export async function createSession(
   branchName: string
 ): Promise<void> {
   await term.type('c');
-  await expect(term.getByText('Branch Picker')).toBeVisible();
+  await expect(term.getByText('Branch Picker')).toBeVisible({ timeout: 5_000 });
   await term.type(branchName);
   await expect(term.getByText(/\(new branch\)/).first()).toBeVisible({
     timeout: 5_000,
@@ -24,5 +24,23 @@ export async function createSession(
   });
   await expect(term.getByText(branchName).first()).toBeVisible({
     timeout: 10_000,
+  });
+}
+
+/**
+ * Wait for the user to be focused on the sidebar. The pane title only
+ * appends "(ctrl+space to exit)" while terminal-focused (see
+ * `getPaneTitle` in focus.ts), so its absence is the cheapest
+ * sidebar-focused signal that works regardless of `autoHideSidebar`.
+ *
+ * Use this after `term.write('\x00')` to escape from a terminal: the
+ * write call returns when CDP acknowledges the page.evaluate, but the
+ * actual focus change requires a WS roundtrip + React reconciliation.
+ * Without this wait, the next keystroke can race the escape and end
+ * up in the still-focused PTY.
+ */
+export async function waitForSidebarFocused(term: KirbyTerm): Promise<void> {
+  await expect(term.getByText(/ctrl\+space to exit/)).not.toBeVisible({
+    timeout: 5_000,
   });
 }

--- a/apps/cli-e2e/src/setup/sessions.ts
+++ b/apps/cli-e2e/src/setup/sessions.ts
@@ -1,0 +1,28 @@
+import { expect, type KirbyTerm } from '../fixtures/kirby.js';
+
+/**
+ * Create a session via the branch picker. After this returns, the
+ * session row is visible in the sidebar with the user still focused on
+ * the sidebar (the PTY has NOT been started yet — use Tab to start +
+ * focus the terminal).
+ */
+export async function createSession(
+  term: KirbyTerm,
+  branchName: string
+): Promise<void> {
+  await term.type('c');
+  await expect(term.getByText('Branch Picker')).toBeVisible();
+  await term.type(branchName);
+  await expect(term.getByText(/\(new branch\)/).first()).toBeVisible({
+    timeout: 5_000,
+  });
+  // Let React re-render so useInput closure captures the updated filter.
+  await term.page.waitForTimeout(2_000);
+  await term.press('Enter');
+  await expect(term.getByText('Branch Picker')).not.toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(term.getByText(branchName).first()).toBeVisible({
+    timeout: 10_000,
+  });
+}

--- a/apps/cli-e2e/src/setup/sessions.ts
+++ b/apps/cli-e2e/src/setup/sessions.ts
@@ -10,8 +10,18 @@ export async function createSession(
   term: KirbyTerm,
   branchName: string
 ): Promise<void> {
-  await term.type('c');
-  await expect(term.getByText('Branch Picker')).toBeVisible({ timeout: 5_000 });
+  // Retry typing 'c' until the branch picker actually opens. A single
+  // 'c' can be lost if focus is in transition: an immediately preceding
+  // Ctrl+Space (\x00) and the 'c' can arrive in a bunched stdin event,
+  // and Ink's sidebar useInput is still inactive in that tick — so the
+  // 'c' is dispatched against the terminal-focused context and dropped.
+  // Re-typing once focus has fully landed lets the next 'c' through.
+  await expect(async () => {
+    await term.type('c');
+    await expect(term.getByText('Branch Picker')).toBeVisible({
+      timeout: 1_500,
+    });
+  }).toPass({ timeout: 8_000, intervals: [500] });
   await term.type(branchName);
   await expect(term.getByText(/\(new branch\)/).first()).toBeVisible({
     timeout: 5_000,

--- a/apps/cli-e2e/src/setup/sessions.ts
+++ b/apps/cli-e2e/src/setup/sessions.ts
@@ -10,18 +10,18 @@ export async function createSession(
   term: KirbyTerm,
   branchName: string
 ): Promise<void> {
-  // Retry typing 'c' until the branch picker actually opens. A single
-  // 'c' can be lost if focus is in transition: an immediately preceding
-  // Ctrl+Space (\x00) and the 'c' can arrive in a bunched stdin event,
-  // and Ink's sidebar useInput is still inactive in that tick — so the
-  // 'c' is dispatched against the terminal-focused context and dropped.
-  // Re-typing once focus has fully landed lets the next 'c' through.
+  // One 'c' can be lost when it bunches into the same stdin chunk as
+  // a preceding Ctrl+Space — the escape fires but Ink's sidebar
+  // useInput is still inactive in that React tick, so the 'c' is
+  // dispatched against the terminal-focused context and dropped. One
+  // retry on the next render cycle is enough; if it takes more than
+  // that, something else is broken.
   await expect(async () => {
     await term.type('c');
     await expect(term.getByText('Branch Picker')).toBeVisible({
-      timeout: 1_500,
+      timeout: 1_000,
     });
-  }).toPass({ timeout: 8_000, intervals: [500] });
+  }).toPass({ timeout: 2_500, intervals: [400] });
   await term.type(branchName);
   await expect(term.getByText(/\(new branch\)/).first()).toBeVisible({
     timeout: 5_000,

--- a/apps/cli/src/activity-config.ts
+++ b/apps/cli/src/activity-config.ts
@@ -1,0 +1,18 @@
+// Tunable thresholds for the sidebar agent-activity indicator.
+// A session counts as "active" when its PTY has emitted a string of at
+// least MIN_DATA_BYTES code units within the last ACTIVITY_IDLE_MS —
+// except during INPUT_ECHO_MS after a keystroke we sent, when the
+// output is almost certainly the terminal echoing user input back.
+export const ACTIVITY_IDLE_MS = 2000;
+export const MIN_DATA_BYTES = 4;
+// 50ms is tight: anything the PTY echoes slightly slower (slow apps,
+// priming on first keystroke) will be miscounted as agent output and
+// produce a brief spurious "active" flicker. Bump to 80–100ms if that
+// turns out to be a problem in the wild.
+export const INPUT_ECHO_MS = 50;
+
+// "Needs attention" flashing: a session that produced output for at
+// least MIN_ACTIVE_MS and then went idle without the user looking at
+// it flashes its title between gray and white at FLASH_INTERVAL_MS.
+export const MIN_ACTIVE_MS = 3000;
+export const FLASH_INTERVAL_MS = 700;

--- a/apps/cli/src/activity.spec.ts
+++ b/apps/cli/src/activity.spec.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { PtySession } from '@kirby/terminal';
+import {
+  __resetForTests,
+  attach,
+  detach,
+  noteInput,
+  noteSeen,
+  snapshot,
+} from './activity.js';
+import {
+  ACTIVITY_IDLE_MS,
+  INPUT_ECHO_MS,
+  MIN_ACTIVE_MS,
+} from './activity-config.js';
+
+class MockPty {
+  private dataCb: ((s: string) => void) | null = null;
+  private exitCb: ((c: number) => void) | null = null;
+  onData = vi.fn((cb: (s: string) => void) => {
+    this.dataCb = cb;
+  });
+  offData = vi.fn(() => {
+    this.dataCb = null;
+  });
+  onExit = vi.fn((cb: (c: number) => void) => {
+    this.exitCb = cb;
+  });
+  offExit = vi.fn(() => {
+    this.exitCb = null;
+  });
+  emit(data: string) {
+    this.dataCb?.(data);
+  }
+  exit(code = 0) {
+    this.exitCb?.(code);
+  }
+  asPty(): PtySession {
+    return this as unknown as PtySession;
+  }
+}
+
+describe('activity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    __resetForTests();
+  });
+
+  afterEach(() => {
+    __resetForTests();
+    vi.useRealTimers();
+  });
+
+  it('reads as QUIET immediately after attach', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+    expect(snapshot('s1')).toEqual({ active: false, flashing: false });
+  });
+
+  it('marks the session active after a real data burst', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    pty.emit('xxxx');
+    expect(snapshot('s1').active).toBe(true);
+
+    vi.advanceTimersByTime(ACTIVITY_IDLE_MS + 1);
+    expect(snapshot('s1').active).toBe(false);
+  });
+
+  it('suppresses output that lands inside the input-echo window', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    noteInput('s1');
+    vi.advanceTimersByTime(INPUT_ECHO_MS - 1);
+    pty.emit('xxxx');
+    expect(snapshot('s1').active).toBe(false);
+  });
+
+  it('counts output once the echo window has expired', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    noteInput('s1');
+    vi.advanceTimersByTime(INPUT_ECHO_MS + 1);
+    pty.emit('xxxx');
+    expect(snapshot('s1').active).toBe(true);
+  });
+
+  it('ignores tiny payloads below the byte threshold', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    pty.emit('a');
+    expect(snapshot('s1').active).toBe(false);
+  });
+
+  it('flashes after a long-enough streak goes idle without being seen', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    // Drive a continuous streak that lasts at least MIN_ACTIVE_MS.
+    pty.emit('xxxx');
+    const ticks = Math.ceil(MIN_ACTIVE_MS / 200) + 1;
+    for (let i = 0; i < ticks; i++) {
+      vi.advanceTimersByTime(200);
+      pty.emit('xxxx');
+    }
+
+    // Let it lapse into idle.
+    vi.advanceTimersByTime(ACTIVITY_IDLE_MS + 1);
+
+    expect(snapshot('s1')).toEqual({ active: false, flashing: true });
+
+    noteSeen('s1');
+    expect(snapshot('s1').flashing).toBe(false);
+  });
+
+  it('does not flash for short streaks', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    pty.emit('xxxx');
+    vi.advanceTimersByTime(200);
+    pty.emit('xxxx');
+    vi.advanceTimersByTime(ACTIVITY_IDLE_MS + 1);
+
+    expect(snapshot('s1').flashing).toBe(false);
+  });
+
+  it('detach unsubscribes from the PTY and makes future calls no-ops', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+    expect(pty.onData).toHaveBeenCalledTimes(1);
+    expect(pty.onExit).toHaveBeenCalledTimes(1);
+
+    detach('s1');
+    expect(pty.offData).toHaveBeenCalledTimes(1);
+    expect(pty.offExit).toHaveBeenCalledTimes(1);
+
+    // No throw, snapshot returns QUIET.
+    noteInput('s1');
+    noteSeen('s1');
+    expect(snapshot('s1')).toEqual({ active: false, flashing: false });
+  });
+
+  it('treats exited sessions as inactive even if recent data arrived', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    pty.emit('xxxx');
+    expect(snapshot('s1').active).toBe(true);
+
+    pty.exit(0);
+    expect(snapshot('s1').active).toBe(false);
+  });
+
+  it('still flashes an exited session whose streak qualified and was never seen', () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    // Qualifying streak.
+    pty.emit('xxxx');
+    const ticks = Math.ceil(MIN_ACTIVE_MS / 200) + 1;
+    for (let i = 0; i < ticks; i++) {
+      vi.advanceTimersByTime(200);
+      pty.emit('xxxx');
+    }
+
+    pty.exit(0);
+    expect(snapshot('s1')).toEqual({ active: false, flashing: true });
+
+    noteSeen('s1');
+    expect(snapshot('s1').flashing).toBe(false);
+  });
+
+  it('re-attach with the same name clears flashing carried over from the previous PTY', () => {
+    const pty1 = new MockPty();
+    attach('s1', pty1.asPty());
+
+    // Build a qualifying streak on pty1 and let it lapse — the session
+    // is now flashing.
+    pty1.emit('xxxx');
+    const ticks = Math.ceil(MIN_ACTIVE_MS / 200) + 1;
+    for (let i = 0; i < ticks; i++) {
+      vi.advanceTimersByTime(200);
+      pty1.emit('xxxx');
+    }
+    vi.advanceTimersByTime(ACTIVITY_IDLE_MS + 1);
+    expect(snapshot('s1').flashing).toBe(true);
+
+    // Respawn the session with the same name: flashing state should not
+    // carry over, since the new process has produced no output yet.
+    const pty2 = new MockPty();
+    attach('s1', pty2.asPty());
+    expect(snapshot('s1')).toEqual({ active: false, flashing: false });
+  });
+
+  it('attach replaces an existing entry and disposes the old PTY listeners', () => {
+    const pty1 = new MockPty();
+    attach('s1', pty1.asPty());
+
+    const pty2 = new MockPty();
+    attach('s1', pty2.asPty());
+
+    expect(pty1.offData).toHaveBeenCalledTimes(1);
+    expect(pty1.offExit).toHaveBeenCalledTimes(1);
+
+    // Old PTY no longer drives the activity for s1.
+    pty1.emit('xxxx');
+    expect(snapshot('s1').active).toBe(false);
+
+    pty2.emit('xxxx');
+    expect(snapshot('s1').active).toBe(true);
+  });
+});

--- a/apps/cli/src/activity.ts
+++ b/apps/cli/src/activity.ts
@@ -1,0 +1,129 @@
+// Tracks per-session "agent activity" derived from PTY output. Owns
+// every rule about what counts as activity, what counts as input echo,
+// when a session needs the user's attention, etc. The pty-registry
+// only calls attach/detach at the lifecycle boundary; everything else
+// (the React hook, the input forwarder) talks to this module by name.
+
+import type { PtySession } from '@kirby/terminal';
+import {
+  ACTIVITY_IDLE_MS,
+  INPUT_ECHO_MS,
+  MIN_ACTIVE_MS,
+  MIN_DATA_BYTES,
+} from './activity-config.js';
+
+interface SessionActivity {
+  exited: boolean;
+  /** Last PTY output we attributed to the agent (not echo, not noise),
+   * or null if the session has not produced qualifying output yet. */
+  lastDataAt: number | null;
+  /** Last keystroke we forwarded to the PTY. */
+  lastInputAt: number;
+  /** Start of the current active streak, or null when idle. */
+  activeSince: number | null;
+  /** Wall time the user last viewed this session. */
+  lastSeenAt: number;
+  /** Cleanup for the onData/onExit subscriptions we own. */
+  dispose: () => void;
+}
+
+const sessions = new Map<string, SessionActivity>();
+
+export function attach(name: string, pty: PtySession): void {
+  detach(name);
+
+  const state: SessionActivity = {
+    exited: false,
+    // null = "session has never produced qualifying output". Seeding
+    // with `Date.now()` made every freshly-attached session look active
+    // for the first ACTIVITY_IDLE_MS.
+    lastDataAt: null,
+    // -Infinity so any data at t=0 is outside the echo window. Using 0
+    // would have suppressed the first emit when Date.now() happened to
+    // read 0 (fake timers in tests; never in real life).
+    lastInputAt: Number.NEGATIVE_INFINITY,
+    activeSince: null,
+    lastSeenAt: Date.now(),
+    dispose: () => undefined,
+  };
+
+  const onData = (data: string) => {
+    if (data.length < MIN_DATA_BYTES) return;
+    const t = Date.now();
+    // Suppress data that arrived within the echo window of an input we
+    // sent — that's the terminal echoing the keystroke back, not the
+    // agent doing work.
+    if (t - state.lastInputAt < INPUT_ECHO_MS) return;
+    // Open a new active streak when this is either the first ever data
+    // or the previous streak had time to lapse into idle.
+    if (
+      state.activeSince == null ||
+      state.lastDataAt == null ||
+      t - state.lastDataAt > ACTIVITY_IDLE_MS
+    ) {
+      state.activeSince = t;
+    }
+    state.lastDataAt = t;
+  };
+  const onExit = () => {
+    // Leave lastDataAt alone: it marks the time of the last actual
+    // output, which is what drives "unseen output" flashing. Stamping
+    // it to Date.now() here would hide the exit from that check.
+    state.exited = true;
+  };
+
+  pty.onData(onData);
+  pty.onExit(onExit);
+  state.dispose = () => {
+    pty.offData(onData);
+    pty.offExit(onExit);
+  };
+
+  sessions.set(name, state);
+}
+
+export function detach(name: string): void {
+  const state = sessions.get(name);
+  if (!state) return;
+  state.dispose();
+  sessions.delete(name);
+}
+
+export function noteInput(name: string): void {
+  const state = sessions.get(name);
+  if (state) state.lastInputAt = Date.now();
+}
+
+/** Acknowledge that the user has seen everything the session has
+ * produced up to now — clears any pending "needs attention" state. */
+export function noteSeen(name: string): void {
+  const state = sessions.get(name);
+  if (state) state.lastSeenAt = Date.now();
+}
+
+export interface ActivitySnapshot {
+  /** Agent is currently producing output. */
+  active: boolean;
+  /** Session ran for at least MIN_ACTIVE_MS, then went idle, and the
+   * user hasn't looked at it since the most recent output. */
+  flashing: boolean;
+}
+
+const QUIET: ActivitySnapshot = { active: false, flashing: false };
+
+export function __resetForTests(): void {
+  for (const state of sessions.values()) state.dispose();
+  sessions.clear();
+}
+
+export function snapshot(name: string): ActivitySnapshot {
+  const state = sessions.get(name);
+  if (!state || state.lastDataAt == null) return QUIET;
+  const t = Date.now();
+  const active = !state.exited && t - state.lastDataAt < ACTIVITY_IDLE_MS;
+  const streakMs =
+    state.activeSince != null ? state.lastDataAt - state.activeSince : 0;
+  const flashing =
+    !active && streakMs >= MIN_ACTIVE_MS && state.lastDataAt > state.lastSeenAt;
+  return active === false && flashing === false ? QUIET : { active, flashing };
+}

--- a/apps/cli/src/components/RainbowSpinner.tsx
+++ b/apps/cli/src/components/RainbowSpinner.tsx
@@ -1,0 +1,11 @@
+import { Text } from 'ink';
+import {
+  COLORS,
+  SPINNER_GLYPHS,
+  useSpinnerFrame,
+} from '../hooks/useActivity.js';
+
+export function RainbowSpinner() {
+  const { frame, colorIndex } = useSpinnerFrame();
+  return <Text color={COLORS[colorIndex]}>{SPINNER_GLYPHS[frame]}</Text>;
+}

--- a/apps/cli/src/components/SettingsPanel.tsx
+++ b/apps/cli/src/components/SettingsPanel.tsx
@@ -110,6 +110,14 @@ export function buildSettingsFields(
       configBag: 'global',
     },
     {
+      label: 'Jump to Inactive Session on Ctrl+Space',
+      key: 'jumpToInactiveOnEscape',
+      description:
+        'When agents go idle, queue them and jump on Ctrl+Space instead of returning to the sidebar',
+      presets: BOOL_PRESETS_ON_FIRST,
+      configBag: 'global',
+    },
+    {
       label: 'Diff File List Tree',
       key: 'diffFileListTree',
       description: 'Group PR files by directory in the diff file list',

--- a/apps/cli/src/components/Sidebar.tsx
+++ b/apps/cli/src/components/Sidebar.tsx
@@ -1,13 +1,17 @@
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useMemo, type ReactNode } from 'react';
 import { Text, Box } from 'ink';
 import { Divider } from './Divider.js';
 import type { PullRequestInfo } from '@kirby/vcs-core';
 import type { AgentSession, SidebarItem } from '../types.js';
 import { PrBadge } from './PrBadge.js';
+import { RainbowSpinner } from './RainbowSpinner.js';
 import { SidebarLayout } from './SidebarLayout.js';
 import { computeScrollWindow } from '../utils/scroll-window.js';
 import { useConfig } from '../context/ConfigContext.js';
 import { useKeybindResolve } from '../context/KeybindContext.js';
+import { useActivityStatus, useFlashPhase } from '../hooks/useActivity.js';
+import { noteSeen } from '../activity.js';
+import { remove as removeInactiveAlert } from '../inactive-alerts.js';
 import { LAYOUT } from '../context/LayoutContext.js';
 
 // ── Constants ───────────────────────────────────────────────────
@@ -51,6 +55,26 @@ const SECTION_LABELS: Record<SectionKey, { title: string; color: string }> = {
 
 // ── Sub-components ──────────────────────────────────────────────
 
+// Leaf component that owns the "needs attention" flash cadence. The
+// row's conflict/badge siblings don't reconcile on every phase flip,
+// but the enclosing <Text wrap="truncate"> does re-measure at ~1.43Hz —
+// Ink's truncation needs the whole string in one <Text>, so the flash
+// can't be a pure sibling of the title text.
+function FlashingTitle({
+  children,
+  bold,
+}: {
+  children: ReactNode;
+  bold: boolean;
+}) {
+  const phase = useFlashPhase();
+  return (
+    <Text bold={bold} color={phase === 0 ? 'gray' : 'white'}>
+      {children}
+    </Text>
+  );
+}
+
 const SessionItemRow = memo(function SessionItemRow({
   session,
   selected,
@@ -81,18 +105,56 @@ const SessionItemRow = memo(function SessionItemRow({
     iconColor = session.running ? 'green' : 'gray';
   }
 
+  const activity = useActivityStatus(session.name);
+  const title = pr?.title || session.name;
+
+  // The selected row is what the user is looking at, so ack any output
+  // (poll while selected, plus a final ack on deselect) — that way the
+  // row does not flash the moment it is deselected. Runs at 1Hz; flash
+  // requires ACTIVITY_IDLE_MS (2s) of silence after data, so a single
+  // missed tick at the tail can't make the flash appear for content
+  // the user actually saw.
+  useEffect(() => {
+    if (!selected) return;
+    noteSeen(session.name);
+    // Visiting acks any pending inactive-alert: the user is here, they
+    // don't need a queued jump back to a session they're already on.
+    removeInactiveAlert(session.name);
+    const id = setInterval(() => noteSeen(session.name), 1000);
+    return () => {
+      clearInterval(id);
+      noteSeen(session.name);
+    };
+  }, [selected, session.name]);
+
+  // Short-circuit animations for the selected row: the user can see it
+  // live in the terminal pane, so the indicator would be visual noise.
+  const showFlash = !selected && activity.flashing;
+  const showSpinner = !selected && activity.active;
+
   return (
     <Box flexDirection="column">
-      <Text wrap="truncate">
-        <Text color={iconColor}>{icon} </Text>
-        <Text bold={selected}>{pr?.title || session.name}</Text>
-        {isMerged ? (
-          <Text dimColor color="green">
-            {' '}
-            merged
+      <Box>
+        <Box flexGrow={1} flexShrink={1} minWidth={0}>
+          <Text wrap="truncate">
+            <Text color={iconColor}>{icon} </Text>
+            {showFlash ? (
+              <FlashingTitle bold={selected}>{title}</FlashingTitle>
+            ) : (
+              <Text bold={selected}>{title}</Text>
+            )}
+            {isMerged ? (
+              <Text dimColor color="green">
+                {' '}
+                merged
+              </Text>
+            ) : null}
           </Text>
-        ) : null}
-      </Text>
+        </Box>
+        <Box flexShrink={0} marginLeft={1} width={1}>
+          {showSpinner ? <RainbowSpinner /> : <Text> </Text>}
+        </Box>
+      </Box>
       {conflictCount != null && conflictCount > 0 ? (
         <Text dimColor color="yellow">
           {'  '}

--- a/apps/cli/src/context/ConfigContext.tsx
+++ b/apps/cli/src/context/ConfigContext.tsx
@@ -43,6 +43,7 @@ function coerceConfigValue(
     key === 'autoDeleteOnMerge' ||
     key === 'autoRebase' ||
     key === 'autoHideSidebar' ||
+    key === 'jumpToInactiveOnEscape' ||
     key === 'diffFileListTree'
   ) {
     return value === 'true';

--- a/apps/cli/src/hooks/useActivity.spec.tsx
+++ b/apps/cli/src/hooks/useActivity.spec.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Text, Box } from 'ink';
+import { render } from 'ink-testing-library';
+import type { PtySession } from '@kirby/terminal';
+import { attach, __resetForTests as resetActivity } from '../activity.js';
+import { ACTIVITY_IDLE_MS } from '../activity-config.js';
+import { RainbowSpinner } from '../components/RainbowSpinner.js';
+import {
+  useActivityStatus,
+  useSpinnerFrame,
+  __resetForTests as resetHooks,
+  __timerActiveForTests,
+  __subscriberCountForTests,
+} from './useActivity.js';
+
+class MockPty {
+  private dataCb: ((s: string) => void) | null = null;
+  private exitCb: ((c: number) => void) | null = null;
+  onData = vi.fn((cb: (s: string) => void) => {
+    this.dataCb = cb;
+  });
+  offData = vi.fn(() => {
+    this.dataCb = null;
+  });
+  onExit = vi.fn((cb: (c: number) => void) => {
+    this.exitCb = cb;
+  });
+  offExit = vi.fn(() => {
+    this.exitCb = null;
+  });
+  emit(data: string) {
+    this.dataCb?.(data);
+  }
+  asPty(): PtySession {
+    return this as unknown as PtySession;
+  }
+}
+
+function SpinnerHarness() {
+  const f = useSpinnerFrame();
+  return <Text>{`${f.frame}:${f.colorIndex}`}</Text>;
+}
+
+// Mirrors the Sidebar's render logic for active sessions: mounts a
+// RainbowSpinner when useActivityStatus reports active. Used to verify
+// the end-to-end "spinner disappears when the session goes idle"
+// behavior that the hook alone can't prove. The `_` placeholder stands
+// in where the spinner isn't mounted so the column is detectable (Ink
+// trims trailing whitespace from rendered frames).
+function RowHarness({ name }: { name: string }) {
+  const s = useActivityStatus(name);
+  return (
+    <Box>
+      {s.active ? <RainbowSpinner /> : <Text>_</Text>}
+      <Text>{`|${s.active ? 'A' : '-'}${s.flashing ? 'F' : '-'}`}</Text>
+    </Box>
+  );
+}
+
+// Yield once so ink flushes useEffect + any setState-triggered re-render
+// into `lastFrame()`.
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('useActivity shared ticker', () => {
+  beforeEach(() => {
+    resetActivity();
+    resetHooks();
+  });
+
+  afterEach(() => {
+    resetActivity();
+    resetHooks();
+  });
+
+  it('starts the ticker when the first subscriber mounts and stops it when the last unmounts', async () => {
+    expect(__timerActiveForTests()).toBe(false);
+    expect(__subscriberCountForTests()).toBe(0);
+
+    const h = render(<SpinnerHarness />);
+    await flush();
+    expect(__timerActiveForTests()).toBe(true);
+    expect(__subscriberCountForTests()).toBe(1);
+
+    h.unmount();
+    await flush();
+    expect(__timerActiveForTests()).toBe(false);
+    expect(__subscriberCountForTests()).toBe(0);
+  });
+
+  it('shares one ticker across multiple subscribers', async () => {
+    const a = render(<SpinnerHarness />);
+    const b = render(<SpinnerHarness />);
+    await flush();
+
+    expect(__timerActiveForTests()).toBe(true);
+    expect(__subscriberCountForTests()).toBe(2);
+
+    a.unmount();
+    await flush();
+    expect(__timerActiveForTests()).toBe(true);
+    expect(__subscriberCountForTests()).toBe(1);
+
+    b.unmount();
+    await flush();
+    expect(__timerActiveForTests()).toBe(false);
+    expect(__subscriberCountForTests()).toBe(0);
+  });
+});
+
+describe('spinner mounts and unmounts with activity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    resetActivity();
+    resetHooks();
+  });
+
+  afterEach(() => {
+    resetActivity();
+    resetHooks();
+    vi.useRealTimers();
+  });
+
+  it('renders the spinner while active and clears it after the session goes idle', async () => {
+    const pty = new MockPty();
+    attach('s1', pty.asPty());
+
+    pty.emit('xxxx');
+    const h = render(<RowHarness name="s1" />);
+    // Flush ink's render scheduler + any pending microtasks so the
+    // initial compute() result is reflected in lastFrame().
+    await vi.advanceTimersByTimeAsync(100);
+    const activeFrame = h.lastFrame() ?? '';
+    expect(activeFrame).toContain('|A-');
+    expect(activeFrame).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
+
+    await vi.advanceTimersByTimeAsync(ACTIVITY_IDLE_MS + 100);
+    const idleFrame = h.lastFrame() ?? '';
+    expect(idleFrame).toContain('_|--');
+    expect(idleFrame).not.toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
+
+    h.unmount();
+  });
+});

--- a/apps/cli/src/hooks/useActivity.ts
+++ b/apps/cli/src/hooks/useActivity.ts
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { snapshot, type ActivitySnapshot } from '../activity.js';
+import { FLASH_INTERVAL_MS } from '../activity-config.js';
+
+const TICK_MS = 100;
+
+export const SPINNER_GLYPHS = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
+export const COLORS = [
+  'red',
+  'yellow',
+  'green',
+  'cyan',
+  'blue',
+  'magenta',
+] as const;
+
+// One shared ticker drives every visible row's animation so we don't
+// run N timers for N sessions.
+const subscribers = new Set<() => void>();
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function subscribe(cb: () => void): () => void {
+  subscribers.add(cb);
+  if (timer == null) {
+    timer = setInterval(() => {
+      // Snapshot before iterating: a callback may synchronously
+      // subscribe/unsubscribe others (mount/unmount during commit).
+      for (const fn of [...subscribers]) fn();
+    }, TICK_MS);
+  }
+  return () => {
+    subscribers.delete(cb);
+    if (subscribers.size === 0 && timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+export function __resetForTests(): void {
+  subscribers.clear();
+  if (timer != null) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+export function __timerActiveForTests(): boolean {
+  return timer != null;
+}
+
+export function __subscriberCountForTests(): number {
+  return subscribers.size;
+}
+
+// ── Status hook (slow-changing) ─────────────────────────────────
+
+const QUIET: ActivitySnapshot = { active: false, flashing: false };
+
+/**
+ * Returns the slow-changing activity state for a row: whether the
+ * spinner should be mounted and whether the title should be flashing.
+ * Pure — side effects (like acknowledging a selected row with
+ * `noteSeen`) belong in the consumer. Updates only when `active` or
+ * `flashing` flips, so consuming it does NOT cause the row to
+ * re-render every spinner tick.
+ */
+export function useActivityStatus(name: string): ActivitySnapshot {
+  const [state, setState] = useState<ActivitySnapshot>(QUIET);
+
+  useEffect(() => {
+    const compute = () => {
+      const next = snapshot(name);
+      setState((prev) =>
+        prev.active === next.active && prev.flashing === next.flashing
+          ? prev
+          : next
+      );
+    };
+    compute();
+    return subscribe(compute);
+  }, [name]);
+
+  return state;
+}
+
+// ── Flash-phase hook (used by the flashing title leaf) ─────────
+
+/**
+ * Returns 0 or 1, alternating every FLASH_INTERVAL_MS. Mount this only
+ * inside the leaf title component that paints the flash — that way the
+ * row above does not reconcile on every phase flip.
+ *
+ * Phase is re-evaluated on the shared ticker (TICK_MS), so flips can be
+ * up to TICK_MS late; the setPhase equality guard means re-renders fire
+ * only on actual phase transitions (~1.43Hz at FLASH_INTERVAL_MS=700).
+ */
+export function useFlashPhase(): number {
+  const [phase, setPhase] = useState(
+    () => Math.floor(Date.now() / FLASH_INTERVAL_MS) % 2
+  );
+
+  useEffect(() => {
+    const tick = () => {
+      const next = Math.floor(Date.now() / FLASH_INTERVAL_MS) % 2;
+      setPhase((prev) => (prev === next ? prev : next));
+    };
+    return subscribe(tick);
+  }, []);
+
+  return phase;
+}
+
+// ── Spinner-frame hook (fast-changing) ──────────────────────────
+
+export interface SpinnerFrame {
+  frame: number;
+  colorIndex: number;
+}
+
+/**
+ * Returns the per-tick spinner glyph + color index. The spinner is
+ * supposed to advance every tick, so there's no equality guard — mount
+ * this hook only inside the leaf component that paints the spinner, so
+ * the row above doesn't reconcile on every tick.
+ *
+ * Each row counts its own ticks (mounted-since), so spinners on
+ * different rows may be out of phase. That's fine and avoids any
+ * shared state.
+ */
+export function useSpinnerFrame(): SpinnerFrame {
+  const [tick, setTick] = useState(0);
+  useEffect(() => subscribe(() => setTick((n) => n + 1)), []);
+  return {
+    frame: tick % SPINNER_GLYPHS.length,
+    colorIndex: Math.floor(tick / 2) % COLORS.length,
+  };
+}

--- a/apps/cli/src/hooks/useInactiveAlertWatcher.ts
+++ b/apps/cli/src/hooks/useInactiveAlertWatcher.ts
@@ -1,0 +1,56 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { snapshot } from '../activity.js';
+import { enqueue as enqueueAlert } from '../inactive-alerts.js';
+import { useToastActions } from '../context/ToastContext.js';
+import { useConfig } from '../context/ConfigContext.js';
+import { useSessionData } from '../context/SessionContext.js';
+
+const POLL_MS = 250;
+
+/**
+ * Watches every running session's activity state and fires an info
+ * toast + enqueues the session name into the inactive-alerts queue
+ * when it transitions active → idle. Mount once at app level.
+ *
+ * The currently-viewed session is suppressed — the user is already
+ * looking at it, so they don't need a toast or a queued jump.
+ *
+ * Off-screen sidebar rows aren't mounted, so a per-row detector would
+ * miss transitions for sessions the user hasn't scrolled to. This hook
+ * iterates the SessionContext's full list, so every running session is
+ * tracked regardless of sidebar visibility.
+ */
+export function useInactiveAlertWatcher(currentlyViewed: string | null): void {
+  const { sessions } = useSessionData();
+  const { flash } = useToastActions();
+  const { config } = useConfig();
+
+  const sessionsRef = useRef(sessions);
+  const viewedRef = useRef(currentlyViewed);
+  const jumpEnabledRef = useRef(config.jumpToInactiveOnEscape !== false);
+  const prevActive = useRef<Map<string, boolean>>(new Map());
+
+  useLayoutEffect(() => {
+    sessionsRef.current = sessions;
+    viewedRef.current = currentlyViewed;
+    jumpEnabledRef.current = config.jumpToInactiveOnEscape !== false;
+  });
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const prev = prevActive.current;
+      const next = new Map<string, boolean>();
+      for (const s of sessionsRef.current) {
+        const cur = snapshot(s.name).active;
+        next.set(s.name, cur);
+        const wasActive = prev.get(s.name) === true;
+        if (wasActive && !cur && s.name !== viewedRef.current) {
+          flash(`${s.name} is idle`, 'info');
+          if (jumpEnabledRef.current) enqueueAlert(s.name);
+        }
+      }
+      prevActive.current = next;
+    }, POLL_MS);
+    return () => clearInterval(id);
+  }, [flash]);
+}

--- a/apps/cli/src/hooks/usePtySession.ts
+++ b/apps/cli/src/hooks/usePtySession.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import type { MouseTrackingMode } from '@kirby/terminal';
 import { getSession } from '../pty-registry.js';
 import type { PtyEntry } from '../pty-registry.js';
+import { noteInput } from '../activity.js';
 
 export function usePtySession(
   sessionName: string | null,
@@ -77,14 +78,17 @@ export function usePtySession(
     }
   }, [paneCols, paneRows, scheduleRender]);
 
-  const write = useCallback((data: string) => {
-    const entry = entryRef.current;
-    if (entry && !entry.exited) {
+  const write = useCallback(
+    (data: string) => {
+      const entry = entryRef.current;
+      if (!entry || entry.exited || !sessionName) return;
       // Reset scroll position on user input
       scrollOffsetRef.current = 0;
+      noteInput(sessionName);
       entry.pty.write(data);
-    }
-  }, []);
+    },
+    [sessionName]
+  );
 
   const scrollUp = useCallback(() => {
     const entry = entryRef.current;

--- a/apps/cli/src/hooks/useRawStdinForward.spec.ts
+++ b/apps/cli/src/hooks/useRawStdinForward.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  processStdinChunk,
+  type StdinChunkContext,
+} from './useRawStdinForward.js';
+
+function makeCtx(
+  overrides: Partial<StdinChunkContext> = {}
+): StdinChunkContext & {
+  write: ReturnType<typeof vi.fn>;
+  onEscape: ReturnType<typeof vi.fn>;
+  onScrollUp: ReturnType<typeof vi.fn>;
+  onScrollDown: ReturnType<typeof vi.fn>;
+} {
+  return {
+    write: vi.fn(),
+    onEscape: vi.fn(),
+    mouseMode: 'none',
+    onScrollUp: vi.fn(),
+    onScrollDown: vi.fn(),
+    ...overrides,
+  } as StdinChunkContext & {
+    write: ReturnType<typeof vi.fn>;
+    onEscape: ReturnType<typeof vi.fn>;
+    onScrollUp: ReturnType<typeof vi.fn>;
+    onScrollDown: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('processStdinChunk', () => {
+  it('forwards plain typed bytes to the PTY', () => {
+    const ctx = makeCtx();
+    processStdinChunk('abc', ctx);
+    expect(ctx.write).toHaveBeenCalledExactlyOnceWith('abc');
+    expect(ctx.onEscape).not.toHaveBeenCalled();
+  });
+
+  it('triggers escape on a stand-alone NUL', () => {
+    const ctx = makeCtx();
+    processStdinChunk('\x00', ctx);
+    expect(ctx.onEscape).toHaveBeenCalledOnce();
+    expect(ctx.write).not.toHaveBeenCalled();
+  });
+
+  it('triggers escape and drops the suffix when NUL leads a chunk', () => {
+    // Reproduces the CI race: under load, the WS sends \x00 and the
+    // next keystroke ('c') bunch into a single stdin event. The escape
+    // must still fire and the 'c' must NOT leak into the agent PTY.
+    const ctx = makeCtx();
+    processStdinChunk('\x00c', ctx);
+    expect(ctx.onEscape).toHaveBeenCalledOnce();
+    expect(ctx.write).not.toHaveBeenCalled();
+  });
+
+  it('forwards the prefix and then escapes when NUL ends a chunk', () => {
+    // 'abc' was real typing the user wants the agent to see; the
+    // trailing \x00 means "now switch back to the sidebar." Both halves
+    // must land.
+    const ctx = makeCtx();
+    processStdinChunk('abc\x00', ctx);
+    expect(ctx.write).toHaveBeenCalledExactlyOnceWith('abc');
+    expect(ctx.onEscape).toHaveBeenCalledOnce();
+  });
+
+  it('forwards the prefix, escapes, and drops the suffix when NUL is mid-chunk', () => {
+    const ctx = makeCtx();
+    processStdinChunk('a\x00b', ctx);
+    expect(ctx.write).toHaveBeenCalledExactlyOnceWith('a');
+    expect(ctx.onEscape).toHaveBeenCalledOnce();
+  });
+
+  it('forwards everything raw when the child has enabled mouse tracking', () => {
+    const ctx = makeCtx({ mouseMode: 'any' });
+    processStdinChunk('\x1b[<0;10;5M', ctx);
+    expect(ctx.write).toHaveBeenCalledExactlyOnceWith('\x1b[<0;10;5M');
+    expect(ctx.onScrollUp).not.toHaveBeenCalled();
+  });
+
+  it('intercepts scroll-up SGR mouse events when child has not enabled mouse', () => {
+    const ctx = makeCtx();
+    processStdinChunk('\x1b[<64;10;5M', ctx);
+    expect(ctx.onScrollUp).toHaveBeenCalledOnce();
+    expect(ctx.write).not.toHaveBeenCalled();
+  });
+
+  it('intercepts scroll-down SGR mouse events when child has not enabled mouse', () => {
+    const ctx = makeCtx();
+    processStdinChunk('\x1b[<65;10;5M', ctx);
+    expect(ctx.onScrollDown).toHaveBeenCalledOnce();
+    expect(ctx.write).not.toHaveBeenCalled();
+  });
+
+  it('drops non-scroll mouse events but forwards interleaved typing', () => {
+    // Click event (button 0) sandwiched between two real keystrokes —
+    // the click is dropped, the typing reaches the PTY as one chunk.
+    const ctx = makeCtx();
+    processStdinChunk('a\x1b[<0;10;5Mb', ctx);
+    expect(ctx.write).toHaveBeenCalledExactlyOnceWith('ab');
+  });
+});

--- a/apps/cli/src/hooks/useRawStdinForward.ts
+++ b/apps/cli/src/hooks/useRawStdinForward.ts
@@ -35,9 +35,18 @@ export function useRawStdinForward(
 
     const handler = (data: Buffer) => {
       const str = data.toString('utf-8');
-      if (str === '\x00') {
-        // Ctrl+Space → return to sidebar
+      // Ctrl+Space (\x00) → escape back to the sidebar. Match anywhere
+      // in the buffer, not just str === '\x00': under load (esp. CI
+      // runners and PTY readahead) multiple keystrokes can arrive in
+      // one stdin chunk, so '\x00c' would have slipped through and
+      // pushed every byte — including 'c' — into the PTY.
+      const escIdx = str.indexOf('\x00');
+      if (escIdx !== -1) {
         onEscape();
+        // Drop the rest of the chunk: focus is moving away from the
+        // terminal, so any further bytes in this event were typed by a
+        // user who has already escaped. Forwarding them to the PTY
+        // would leak keystrokes into the agent.
         return;
       }
 

--- a/apps/cli/src/hooks/useRawStdinForward.ts
+++ b/apps/cli/src/hooks/useRawStdinForward.ts
@@ -10,6 +10,60 @@ const MOUSE_DISABLE_ALL =
 // eslint-disable-next-line no-control-regex
 const SGR_MOUSE_RE = /\x1b\[<(\d+);(\d+);(\d+)([Mm])/g;
 
+export interface StdinChunkContext {
+  write: (data: string) => void;
+  onEscape: () => void;
+  mouseMode: MouseTrackingMode;
+  onScrollUp: () => void;
+  onScrollDown: () => void;
+}
+
+/**
+ * Pure handler for one stdin chunk. Exported so the spec can drive it
+ * without touching `process.stdin`.
+ *
+ * `\x00` (Ctrl+Space) is the escape-to-sidebar key. It can land inside
+ * a multi-byte chunk under load (PTY readahead, rapid keystrokes), so
+ * we look for it anywhere in the buffer. Bytes before the NUL are
+ * forwarded normally; bytes after are dropped — focus is moving away
+ * from the terminal, so subsequent bytes belong to the next context.
+ */
+export function processStdinChunk(str: string, ctx: StdinChunkContext): void {
+  const escIdx = str.indexOf('\x00');
+  const payload = escIdx === -1 ? str : str.slice(0, escIdx);
+  if (payload.length > 0) forwardToPty(payload, ctx);
+  if (escIdx !== -1) ctx.onEscape();
+}
+
+function forwardToPty(str: string, ctx: StdinChunkContext): void {
+  if (ctx.mouseMode !== 'none') {
+    // Child app wants mouse events — forward everything raw
+    ctx.write(str);
+    return;
+  }
+
+  // Child hasn't enabled mouse — handle scroll ourselves, drop other mouse events
+  let match: RegExpExecArray | null;
+  const parts: string[] = [];
+  let lastIndex = 0;
+
+  SGR_MOUSE_RE.lastIndex = 0;
+  while ((match = SGR_MOUSE_RE.exec(str)) !== null) {
+    if (match.index > lastIndex) parts.push(str.slice(lastIndex, match.index));
+    lastIndex = match.index + match[0].length;
+
+    const btn = parseInt(match[1], 10);
+    if (btn === 64) ctx.onScrollUp();
+    else if (btn === 65) ctx.onScrollDown();
+    // All other mouse events (clicks, drags) are dropped
+  }
+
+  if (lastIndex < str.length) parts.push(str.slice(lastIndex));
+
+  const nonMouse = parts.join('');
+  if (nonMouse.length > 0) ctx.write(nonMouse);
+}
+
 export function useRawStdinForward(
   active: boolean,
   write: (data: string) => void,
@@ -21,9 +75,7 @@ export function useRawStdinForward(
   // Always enable mouse on outer terminal when active
   useEffect(() => {
     if (!active) return;
-
     process.stdout.write(MOUSE_ENABLE);
-
     return () => {
       process.stdout.write(MOUSE_DISABLE_ALL);
     };
@@ -34,60 +86,13 @@ export function useRawStdinForward(
     if (!active) return;
 
     const handler = (data: Buffer) => {
-      const str = data.toString('utf-8');
-      // Ctrl+Space (\x00) → escape back to the sidebar. Match anywhere
-      // in the buffer, not just str === '\x00': under load (esp. CI
-      // runners and PTY readahead) multiple keystrokes can arrive in
-      // one stdin chunk, so '\x00c' would have slipped through and
-      // pushed every byte — including 'c' — into the PTY.
-      const escIdx = str.indexOf('\x00');
-      if (escIdx !== -1) {
-        onEscape();
-        // Drop the rest of the chunk: focus is moving away from the
-        // terminal, so any further bytes in this event were typed by a
-        // user who has already escaped. Forwarding them to the PTY
-        // would leak keystrokes into the agent.
-        return;
-      }
-
-      if (mouseMode !== 'none') {
-        // Child app wants mouse events — forward everything raw
-        write(str);
-        return;
-      }
-
-      // Child hasn't enabled mouse — handle scroll ourselves, drop other mouse events
-      let match: RegExpExecArray | null;
-      const parts: string[] = [];
-      let lastIndex = 0;
-
-      SGR_MOUSE_RE.lastIndex = 0;
-      while ((match = SGR_MOUSE_RE.exec(str)) !== null) {
-        // Collect any non-mouse data before this match
-        if (match.index > lastIndex) {
-          parts.push(str.slice(lastIndex, match.index));
-        }
-        lastIndex = match.index + match[0].length;
-
-        const btn = parseInt(match[1], 10);
-        if (btn === 64) {
-          onScrollUp();
-        } else if (btn === 65) {
-          onScrollDown();
-        }
-        // All other mouse events (clicks, drags) are dropped
-      }
-
-      // Collect any remaining non-mouse data after last match
-      if (lastIndex < str.length) {
-        parts.push(str.slice(lastIndex));
-      }
-
-      // Forward non-mouse data to PTY
-      const nonMouse = parts.join('');
-      if (nonMouse.length > 0) {
-        write(nonMouse);
-      }
+      processStdinChunk(data.toString('utf-8'), {
+        write,
+        onEscape,
+        mouseMode,
+        onScrollUp,
+        onScrollDown,
+      });
     };
     process.stdin.on('data', handler);
     return () => {

--- a/apps/cli/src/inactive-alerts.spec.ts
+++ b/apps/cli/src/inactive-alerts.spec.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetForTests,
+  dequeueOldest,
+  enqueue,
+  peekAll,
+  remove,
+  size,
+  subscribe,
+} from './inactive-alerts.js';
+
+afterEach(() => __resetForTests());
+
+describe('inactive-alerts queue', () => {
+  it('enqueues and dequeues in FIFO order', () => {
+    enqueue('a');
+    enqueue('b');
+    enqueue('c');
+    expect(dequeueOldest()).toBe('a');
+    expect(dequeueOldest()).toBe('b');
+    expect(dequeueOldest()).toBe('c');
+    expect(dequeueOldest()).toBeNull();
+  });
+
+  it('deduplicates: enqueueing an existing name is a no-op', () => {
+    enqueue('a');
+    enqueue('b');
+    enqueue('a');
+    expect(peekAll()).toEqual(['a', 'b']);
+  });
+
+  it('remove() drops a specific name from the middle of the queue', () => {
+    enqueue('a');
+    enqueue('b');
+    enqueue('c');
+    remove('b');
+    expect(peekAll()).toEqual(['a', 'c']);
+  });
+
+  it('remove() of a non-queued name is a no-op', () => {
+    enqueue('a');
+    remove('zzz');
+    expect(peekAll()).toEqual(['a']);
+  });
+
+  it('size() reflects the queue length', () => {
+    expect(size()).toBe(0);
+    enqueue('a');
+    enqueue('b');
+    expect(size()).toBe(2);
+    dequeueOldest();
+    expect(size()).toBe(1);
+  });
+
+  it('notifies subscribers on enqueue / dequeue / remove', () => {
+    const cb = vi.fn();
+    subscribe(cb);
+    enqueue('a');
+    expect(cb).toHaveBeenCalledTimes(1);
+    dequeueOldest();
+    expect(cb).toHaveBeenCalledTimes(2);
+    enqueue('b');
+    remove('b');
+    expect(cb).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not notify on dedup or no-op remove', () => {
+    enqueue('a');
+    const cb = vi.fn();
+    subscribe(cb);
+    enqueue('a'); // dup
+    remove('zzz'); // not present
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('subscribe returns a teardown that detaches', () => {
+    const cb = vi.fn();
+    const off = subscribe(cb);
+    enqueue('a');
+    off();
+    enqueue('b');
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/cli/src/inactive-alerts.ts
+++ b/apps/cli/src/inactive-alerts.ts
@@ -1,0 +1,53 @@
+// Module-level FIFO queue of session names that have transitioned from
+// active → idle and not yet been visited (acked) by the user.
+//
+// Pure module: no React. Subscribers (a hook) translate changes to
+// re-renders. Tests can drive the queue directly via the public API
+// and use __resetForTests to isolate.
+
+const queue: string[] = [];
+const subscribers = new Set<() => void>();
+
+function notify(): void {
+  for (const fn of [...subscribers]) fn();
+}
+
+export function enqueue(name: string): void {
+  if (queue.includes(name)) return;
+  queue.push(name);
+  notify();
+}
+
+export function dequeueOldest(): string | null {
+  const next = queue.shift();
+  if (next === undefined) return null;
+  notify();
+  return next;
+}
+
+export function remove(name: string): void {
+  const idx = queue.indexOf(name);
+  if (idx === -1) return;
+  queue.splice(idx, 1);
+  notify();
+}
+
+export function peekAll(): readonly string[] {
+  return queue;
+}
+
+export function size(): number {
+  return queue.length;
+}
+
+export function subscribe(cb: () => void): () => void {
+  subscribers.add(cb);
+  return () => {
+    subscribers.delete(cb);
+  };
+}
+
+export function __resetForTests(): void {
+  queue.length = 0;
+  subscribers.clear();
+}

--- a/apps/cli/src/pty-registry.ts
+++ b/apps/cli/src/pty-registry.ts
@@ -1,4 +1,6 @@
 import { PtySession, TerminalEmulator } from '@kirby/terminal';
+import * as activity from './activity.js';
+import { remove as removeInactiveAlert } from './inactive-alerts.js';
 
 export interface PtyEntry {
   pty: PtySession;
@@ -22,6 +24,8 @@ export function spawnSession(
   if (existing) {
     existing.pty.dispose();
     existing.emu.dispose();
+    activity.detach(name);
+    removeInactiveAlert(name);
     registry.delete(name);
   }
 
@@ -38,6 +42,7 @@ export function spawnSession(
     entry.exitCode = code;
   });
 
+  activity.attach(name, pty);
   registry.set(name, entry);
   return entry;
 }
@@ -55,15 +60,19 @@ export function killSession(name: string): void {
   if (entry) {
     entry.pty.dispose();
     entry.emu.dispose();
+    activity.detach(name);
+    removeInactiveAlert(name);
     registry.delete(name);
   }
 }
 
 /** Kill all PTY sessions. Called on process exit to prevent orphaned children. */
 export function killAll(): void {
-  for (const entry of registry.values()) {
+  for (const [name, entry] of registry.entries()) {
     entry.pty.dispose();
     entry.emu.dispose();
+    activity.detach(name);
+    removeInactiveAlert(name);
   }
   registry.clear();
 }

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -4,6 +4,8 @@ import { Sidebar } from '../../components/Sidebar.js';
 import { Pane } from '../../components/Pane.js';
 import { useNavState, useNavActions } from '../../context/NavContext.js';
 import { useAsyncOps } from '../../context/AsyncOpsContext.js';
+import { useInactiveAlertWatcher } from '../../hooks/useInactiveAlertWatcher.js';
+import { dequeueOldest } from '../../inactive-alerts.js';
 import {
   useBranchPickerState,
   useBranchPickerActions,
@@ -190,6 +192,20 @@ function MainTabBody({ terminalFocused, showOnboarding, exit }: MainTabProps) {
       }
     : terminal;
 
+  useInactiveAlertWatcher(sidebar.sessionNameForTerminal);
+
+  const jumpEnabled = configCtx.config.jumpToInactiveOnEscape !== false;
+  const onTerminalEscape = useCallback(() => {
+    if (jumpEnabled) {
+      const next = dequeueOldest();
+      if (next != null) {
+        sidebar.selectByKey(`session:${next}`);
+        return; // stay terminal-focused; selection drives which PTY shows
+      }
+    }
+    nav.setFocus('sidebar');
+  }, [jumpEnabled, sidebar, nav]);
+
   return (
     <>
       {!sidebarHidden && (
@@ -209,7 +225,7 @@ function MainTabBody({ terminalFocused, showOnboarding, exit }: MainTabProps) {
           terminalFocused={terminalFocused}
           sessionNameForTerminal={sidebar.sessionNameForTerminal}
           selectedPr={sidebar.selectedPr}
-          onFocusSidebar={() => nav.setFocus('sidebar')}
+          onFocusSidebar={onTerminalEscape}
         />
       </Pane>
     </>

--- a/libs/vcs/core/src/lib/config-store.ts
+++ b/libs/vcs/core/src/lib/config-store.ts
@@ -46,6 +46,7 @@ interface RawGlobalConfig {
   autoDeleteOnMerge?: boolean;
   autoRebase?: boolean;
   autoHideSidebar?: boolean;
+  jumpToInactiveOnEscape?: boolean;
   mergePollInterval?: number;
   editor?: string;
   worktreePath?: string;
@@ -137,6 +138,7 @@ export function readConfig(cwd = process.cwd()): AppConfig {
     autoDeleteOnMerge: global.autoDeleteOnMerge,
     autoRebase: global.autoRebase,
     autoHideSidebar: global.autoHideSidebar,
+    jumpToInactiveOnEscape: global.jumpToInactiveOnEscape,
     mergePollInterval: global.mergePollInterval,
     editor: project.editor ?? global.editor,
     worktreePath: global.worktreePath,

--- a/libs/vcs/core/src/lib/types.ts
+++ b/libs/vcs/core/src/lib/types.ts
@@ -167,6 +167,12 @@ export interface AppConfig {
   autoDeleteOnMerge?: boolean;
   autoRebase?: boolean;
   autoHideSidebar?: boolean;
+  /** When the user presses Ctrl+Space (escape from terminal) and there
+   *  are sessions in the inactive-alert queue, jump focus to the next
+   *  alerting session instead of returning to the sidebar. Defaults to
+   *  true; set to false to keep the original "Ctrl+Space → sidebar"
+   *  behavior. */
+  jumpToInactiveOnEscape?: boolean;
   /** Render the diff file list as a collapsed folder tree instead of
    *  a flat path list. Opt-in; defaults to flat for backwards compat. */
   diffFileListTree?: boolean;


### PR DESCRIPTION
## Summary

Adds a per-session activity indicator with a small ecosystem around it:

- **Rainbow spinner** in the sidebar row of any non-selected session whose agent is producing output. State machine in `activity.ts`; render-time helpers in `useActivity.ts`; leaf component in `RainbowSpinner.tsx`.
- **Idle info toast** when a session transitions active → idle. Suppressed for the currently-viewed session.
- **Inactive-alert queue** (FIFO) of sessions that have gone idle without being acknowledged. New `jumpToInactiveOnEscape` setting (default **on**) reroutes `Ctrl+Space` from the terminal to pop the queue and select the next idle session, instead of returning to the sidebar.
- **Cleanup** wired into `pty-registry` (kill/respawn/killAll) and the sidebar's selection effect (visiting a session acks it).

Plus a scriptable test harness:

- `apps/cli-e2e/src/fixtures/fake-agent.mjs` — small flag-driven Node script that pretends to be an agent (configurable bursts / idle / echo / exit). Spawned via the existing `kirbyConfig.aiCommand` injection point.
- Typed `fakeAgentCommand({...})` helper next to the fixture.
- Four new offline e2e tests (`activity-spinner`, `activity-toast`, `activity-queue` with both setting-on and setting-off variants).

## Test plan

- [x] `npx nx run-many -t typecheck lint test -p cli vcs-core` — green (261 unit tests, 25 specs).
- [x] `npx nx e2e cli-e2e --grep activity-` — green locally (4/4 in 38s).
- [ ] CI runs full `nx affected -t lint test build typecheck e2e` to validate the rest of the suite is unaffected.
- [ ] Manual eyeball: `npx nx serve cli-wterm-host` + open Chrome, create two sessions running the fake agent, confirm spinner appears in the non-selected row, idle toast appears after the burst ends, Ctrl+Space jumps to the alerting session.

## Notes for review

- See [senior-ink-reviewer's review](https://github.com/HermannBjorgvin/Kirby/blob/feature/activity-indicator/.claude/agent-memory/senior-ink-reviewer/activity_indicator_review.md) (verdict: ship as-is, with a few optional polish items).
- The e2e tests use real timers (~5–10s per test) rather than env-var overrides of `ACTIVITY_IDLE_MS` / `MIN_ACTIVE_MS`, so they exercise the actual production thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)