### PR TITLE
fix(cli): persist hide-hints toggle across sidebar navigation

### DIFF
--- a/apps/cli-e2e/src/keybindings.test.ts
+++ b/apps/cli-e2e/src/keybindings.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures/kirby.js';
+import { createSession } from './setup/sessions.js';
 
 // ── Default Preset (Normie) ────────────────────────────────────────
 
@@ -234,6 +235,32 @@ test.describe('Keybindings — Hint Toggle', () => {
     await kirby.term.type('?');
     await expect(kirby.term.getByText('hide hints').first()).toBeVisible();
     await expect(kirby.term.getByText('quit').first()).toBeVisible();
+  });
+
+  test('collapsed hints survive sidebar navigation', async ({ kirby }) => {
+    await expect(kirby.term.getByText('Kirby').first()).toBeVisible();
+
+    // Two sidebar items so j/k actually changes selection.
+    await createSession(kirby.term, 'first');
+    await createSession(kirby.term, 'second');
+
+    // Collapse hints.
+    await kirby.term.type('?');
+    await expect(kirby.term.getByText('show hints').first()).toBeVisible();
+
+    // Navigate the sidebar — used to remount MainTabBody and reset
+    // hintsHidden, restoring the full hint list.
+    await kirby.term.press('ArrowUp');
+    await kirby.term.press('ArrowDown');
+
+    // Hints should still be collapsed.
+    await expect(kirby.term.getByText('show hints').first()).toBeVisible();
+    await expect(kirby.term.getByText('hide hints').first()).not.toBeVisible({
+      timeout: 3_000,
+    });
+    await expect(kirby.term.getByText('quit').first()).not.toBeVisible({
+      timeout: 3_000,
+    });
   });
 });
 

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -36,6 +36,9 @@ interface MainTabProps {
 // changes. Without this guard the selected-item remount would briefly
 // tear down the only useInput in the tree, flipping raw-mode off and
 // causing character echo in the terminal.
+//
+// hintsHidden lives here, not in MainTabBody — the body remounts on
+// every sidebar selection change, which would reset the toggle.
 export function MainTab(props: MainTabProps) {
   useInput(() => {
     // Intentionally empty — see comment above.
@@ -46,14 +49,35 @@ export function MainTab(props: MainTabProps) {
     ? getItemKey(sidebar.selectedItem)
     : 'empty';
 
-  return <MainTabBody key={itemKey} {...props} />;
+  const [hintsHidden, setHintsHidden] = useState(false);
+  const toggleHints = useCallback(() => setHintsHidden((v) => !v), []);
+
+  return (
+    <MainTabBody
+      key={itemKey}
+      {...props}
+      hintsHidden={hintsHidden}
+      toggleHints={toggleHints}
+    />
+  );
+}
+
+interface MainTabBodyProps extends MainTabProps {
+  hintsHidden: boolean;
+  toggleHints: () => void;
 }
 
 // MainTabBody owns the pane state + the real input router. React
 // unmounts and remounts it whenever `itemKey` changes (see MainTab
 // above), so `usePaneReducer`'s lazy initializer picks a fresh pane
 // mode via defaultPaneMode() — no render-time setState to reset.
-function MainTabBody({ terminalFocused, showOnboarding, exit }: MainTabProps) {
+function MainTabBody({
+  terminalFocused,
+  showOnboarding,
+  exit,
+  hintsHidden,
+  toggleHints,
+}: MainTabBodyProps) {
   const navState = useNavState();
   const navActions = useNavActions();
   const nav = useMemo(
@@ -90,9 +114,6 @@ function MainTabBody({ terminalFocused, showOnboarding, exit }: MainTabProps) {
     sidebar.selectedItem,
     sidebar.sessionNameForTerminal
   );
-
-  const [hintsHidden, setHintsHidden] = useState(false);
-  const toggleHints = useCallback(() => setHintsHidden((v) => !v), []);
 
   // ── Input handling (modals + sidebar) ──────────────────────────
   useInput((input, key) => {


### PR DESCRIPTION
## Summary
- `hintsHidden` lived in `MainTabBody`, which `MainTab` remounts on every sidebar selection change via `key={itemKey}`. Each navigation reset the toggle, so pressing `?` to collapse hints was undone the moment the user pressed `j`/`k`/arrow keys.
- Lifted `hintsHidden` + `toggleHints` into the stable `MainTab` parent and pass them down as props.
- Added an e2e regression test under `Keybindings — Hint Toggle` that creates two sessions, collapses hints with `?`, navigates the sidebar, and asserts hints stay collapsed.

## Test plan
- [x] `npx nx e2e cli-e2e -- --grep "Hint Toggle"` — both tests pass (existing toggle test + new navigation regression test).
- [x] `npx tsc -p apps/cli/tsconfig.app.json --noEmit` clean.
- [ ] Manual: open Kirby, press `?` to collapse hints, navigate sidebar with `j`/`k`, confirm hints stay collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)