### PR TITLE
Feature/active sessions tabs on top

### DIFF
--- a/apps/cli-e2e/src/active-tabs.test.ts
+++ b/apps/cli-e2e/src/active-tabs.test.ts
@@ -59,4 +59,110 @@ test.describe('Active-session tab bar', () => {
       timeout: 5_000,
     });
   });
+
+  // Covers the v2 UX changes: spawn-time ordering, sidebar tab-number
+  // prefix, middle truncation. Spawns three sessions in a known order,
+  // kills the middle one (verifies remaining tabs compact), and
+  // restarts it (verifies it lands at the END, not back in its old
+  // slot — browser-tab semantics).
+  test('spawn order is preserved across kill+restart, sidebar prefixes match', async ({
+    kirby,
+  }) => {
+    const longBranch = 'this-is-a-very-long-branch-name';
+    // Middle-truncated form: head=8 ('this-is-'), tail=7 ('ch-name').
+    const longTruncated = 'this-is-…ch-name';
+
+    // Helper: assert the tab bar / sidebar shows `<digit> <label>` for
+    // each entry. Both surfaces are rendered as terminal text and end
+    // up in the page DOM as plain characters in `.term-row`s — getByText
+    // with `.first()` is enough since a row appears in only one pane.
+    const expectTab = async (digit: string, label: string) => {
+      await expect(
+        kirby.term.getByText(`${digit} ${label}`).first()
+      ).toBeVisible({ timeout: 5_000 });
+    };
+    const expectNoTab = async (digit: string, label: string) => {
+      await expect(kirby.term.getByText(`${digit} ${label}`)).not.toBeVisible({
+        timeout: 5_000,
+      });
+    };
+
+    // 1. Spawn order: alpha → long → bravo. Tab into each so the PTY
+    //    starts before moving on (createSession alone doesn't spawn).
+    await createSession(kirby.term, 'alpha');
+    await kirby.term.press('Tab');
+    await expect(
+      kirby.term.getByText('kirby-session-active').first()
+    ).toBeVisible({ timeout: 10_000 });
+    await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
+
+    await createSession(kirby.term, longBranch);
+    await kirby.term.press('Tab');
+    await expect(kirby.term.getByText(/Agent.*ch-name/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
+
+    await createSession(kirby.term, 'bravo');
+    await kirby.term.press('Tab');
+    await expect(kirby.term.getByText(/Agent.*bravo/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
+
+    // 2. Tab bar follows spawn order (NOT alphabetical, which would put
+    //    `bravo` at tab 2). Long branch is middle-truncated.
+    await expectTab('1', 'alpha');
+    await expectTab('2', longTruncated);
+    await expectTab('3', 'bravo');
+
+    // 3. Sidebar prefixes match the tab bar digits. The sidebar shows
+    //    `<digit> <icon> <full-branch-name>` where icon is `●` (running,
+    //    not selected) or `◉` (selected + running). The icon between the
+    //    digit and the name distinguishes the sidebar row from the tab
+    //    bar's `<digit> <label>` rendering.
+    await expect(kirby.term.getByText(/1 [●◉] alpha/).first()).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(
+      kirby.term.getByText(new RegExp(`2 [●◉] ${longBranch}`)).first()
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(kirby.term.getByText(/3 [●◉] bravo/).first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // 4. Sidebar order is alphabetical (alpha, bravo, long-branch);
+    //    bravo is currently selected, so vim 'j' navigates down to the
+    //    long-branch row, which we then kill via Shift+K.
+    await kirby.term.type('j');
+    await expect(
+      sidebarLocator(kirby.term.page, longBranch).selected()
+    ).toBeVisible({ timeout: 5_000 });
+    await kirby.term.type('K'); // Shift+K kills the selected agent
+
+    // Tab bar compacts: alpha stays at 1, bravo shifts up from 3 to 2.
+    await expectTab('1', 'alpha');
+    await expectTab('2', 'bravo');
+    await expectNoTab('2', longTruncated);
+    await expectNoTab('3', 'bravo');
+
+    // 5. Restart the long-branch agent (Tab on its still-selected row).
+    //    It must land at the END (tab 3), not back in its original
+    //    slot at tab 2 — that's browser-tab semantics.
+    await kirby.term.press('Tab');
+    await expect(kirby.term.getByText(/Agent.*ch-name/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
+
+    await expectTab('1', 'alpha');
+    await expectTab('2', 'bravo');
+    await expectTab('3', longTruncated);
+    // bravo is no longer at tab 3 (compacted up earlier, now back to 2).
+    await expectNoTab('3', 'bravo');
+  });
 });

--- a/apps/cli-e2e/src/active-tabs.test.ts
+++ b/apps/cli-e2e/src/active-tabs.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from './fixtures/kirby.js';
+import { sidebarLocator } from './setup/sidebar.js';
+import { createSession, waitForSidebarFocused } from './setup/sessions.js';
+
+// Quiet agents that just print a banner then sleep keep the PTYs alive
+// without producing the bursty output the activity tests need —
+// perfect for exercising input plumbing.
+test.use({
+  kirbyConfig: {
+    aiCommand: 'echo kirby-session-active && sleep 300',
+    autoHideSidebar: false,
+    keybindPreset: 'vim',
+  },
+});
+
+test.describe('Active-session tab bar', () => {
+  test('Ctrl+Space + digit selects the Nth running tab and focuses terminal', async ({
+    kirby,
+  }) => {
+    // 1. Create `alpha` and start its PTY.
+    await createSession(kirby.term, 'alpha');
+    await kirby.term.press('Tab');
+    await expect(
+      kirby.term.getByText('kirby-session-active').first()
+    ).toBeVisible({ timeout: 10_000 });
+    await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
+
+    // 2. Create `beta` and start its PTY. Focus is now in beta's
+    //    terminal; both sessions are running.
+    await createSession(kirby.term, 'beta');
+    await kirby.term.press('Tab');
+    await expect(kirby.term.getByText(/Agent.*beta/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // 3. The tab bar above the agent terminal lists both running sessions
+    //    in sidebar order (alpha → 1, beta → 2) since neither has a PR.
+    await expect(kirby.term.getByText('1 alpha').first()).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(kirby.term.getByText('2 beta').first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // 4. Ctrl+Space focuses the sidebar; '1' jumps to alpha and lands
+    //    focus straight back in the terminal.
+    await kirby.term.write('\x00');
+    await waitForSidebarFocused(kirby.term);
+    await kirby.term.type('1');
+
+    // Selection moved to alpha (◉ ring icon in front of the row).
+    await expect(
+      sidebarLocator(kirby.term.page, 'alpha').selected()
+    ).toBeVisible({ timeout: 5_000 });
+    // Pane title's "(ctrl+space to exit)" hint only renders when the
+    // terminal is focused — its presence proves the focus jump.
+    await expect(kirby.term.getByText(/ctrl\+space to exit/)).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});

--- a/apps/cli/src/components/SessionTabBar.spec.tsx
+++ b/apps/cli/src/components/SessionTabBar.spec.tsx
@@ -7,12 +7,16 @@ import type { SidebarItem, AgentSession } from '../types.js';
 import type { SidebarContextValue } from '../context/SidebarContext.js';
 import type { SessionDataContextValue } from '../context/SessionContext.js';
 
-// Stub the two hooks the component reads. Each test installs its own
-// values via setSidebarValue / setSessionValue before rendering — this
-// avoids spinning up the full provider tree (which pulls live git
-// state, PR fetching, etc.).
+// Stub the hooks/registries the component reads. Each test installs
+// its own values before rendering — this avoids spinning up the full
+// provider tree (which pulls live git state, PR fetching, etc.).
 let sidebarValue: Partial<SidebarContextValue> = {};
 let sessionValue: Partial<SessionDataContextValue> = {};
+// Maps session name → ms-since-epoch spawn time. Drives spawn-order
+// sort. Tests that don't care about ordering omit names from this map
+// (they sort to the end via Infinity but with all infinities the sort
+// is a no-op, so order matches `items` declaration).
+let spawnedAtMap = new Map<string, number>();
 
 vi.mock('../context/SidebarContext.js', () => ({
   useSidebar: () => sidebarValue,
@@ -20,6 +24,10 @@ vi.mock('../context/SidebarContext.js', () => ({
 
 vi.mock('../context/SessionContext.js', () => ({
   useSessionData: () => sessionValue,
+}));
+
+vi.mock('../pty-registry.js', () => ({
+  getSpawnedAt: (name: string) => spawnedAtMap.get(name),
 }));
 
 // Imported AFTER vi.mock — required so the mocks are wired in.
@@ -60,6 +68,21 @@ function setSidebar(items: SidebarItem[], selectedIndex = 0) {
     items,
     selectedIndex,
   };
+  // By default, give each running session a monotonically increasing
+  // spawn time matching its declared order — so the tab bar's spawn
+  // order matches the items array order. Individual tests can override
+  // by calling setSpawnOrder directly after.
+  spawnedAtMap = new Map();
+  let t = 1;
+  for (const item of items) {
+    if (item.kind === 'session' && item.session.running) {
+      spawnedAtMap.set(item.session.name, t++);
+    }
+  }
+}
+
+function setSpawnOrder(order: string[]) {
+  spawnedAtMap = new Map(order.map((name, i) => [name, i + 1]));
 }
 
 function setSessions(prMap: Map<string, PullRequestInfo>) {
@@ -71,6 +94,7 @@ function setSessions(prMap: Map<string, PullRequestInfo>) {
 beforeEach(() => {
   sidebarValue = {};
   sessionValue = {};
+  spawnedAtMap = new Map();
 });
 
 // ── Tests ────────────────────────────────────────────────────────
@@ -115,16 +139,28 @@ describe('SessionTabBar', () => {
     expect(text).toContain('2 beta');
   });
 
-  it('truncates long branch names with an ellipsis', () => {
+  it('middle-truncates long branch names at a 16-char cap', () => {
     setSidebar([
       makeSessionItem('this-is-a-very-long-branch-name', { running: true }),
     ]);
     setSessions(new Map());
 
     const text = stripAnsi(render(<SessionTabBar />).lastFrame() ?? '');
-    // 10-char cap with trailing ellipsis: "1 this-is-a…"
-    expect(text).toContain('1 this-is-a…');
-    expect(text).not.toContain('long-branch-name');
+    // 16-char cap, middle ellipsis: head=8 ('this-is-'), tail=7
+    // ('ch-name'). Full label "1 this-is-…ch-name".
+    expect(text).toContain('1 this-is-…ch-name');
+    // Sanity: the dropped middle ('a-very-long-bran') is not present.
+    expect(text).not.toContain('a-very-long');
+  });
+
+  it('renders short names whole when they fit under the cap', () => {
+    setSidebar([
+      makeSessionItem('short-name', { running: true }), // 10 chars
+    ]);
+    setSessions(new Map());
+    const text = stripAnsi(render(<SessionTabBar />).lastFrame() ?? '');
+    expect(text).toContain('1 short-name');
+    expect(text).not.toContain('…');
   });
 
   it('uses 0 as the digit for the 10th tab', () => {
@@ -151,6 +187,24 @@ describe('SessionTabBar', () => {
     expect(text).toContain('+3');
     expect(text).not.toContain('s11');
     expect(text).not.toContain('s13');
+  });
+
+  it('orders tabs by spawn time, not items array order', () => {
+    // Items declared in alphabetical order…
+    setSidebar([
+      makeSessionItem('alpha', { running: true }),
+      makeSessionItem('beta', { running: true }),
+      makeSessionItem('gamma', { running: true }),
+    ]);
+    setSessions(new Map());
+    // …but the user spawned them in a different order: gamma first,
+    // then alpha, then beta. Tabs should reflect spawn order.
+    setSpawnOrder(['gamma', 'alpha', 'beta']);
+
+    const text = stripAnsi(render(<SessionTabBar />).lastFrame() ?? '');
+    expect(text).toContain('1 gamma');
+    expect(text).toContain('2 alpha');
+    expect(text).toContain('3 beta');
   });
 
   it('marks the currently-selected session tab with inverse styling', () => {

--- a/apps/cli/src/components/SessionTabBar.spec.tsx
+++ b/apps/cli/src/components/SessionTabBar.spec.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import stripAnsi from 'strip-ansi';
+import type { PullRequestInfo } from '@kirby/vcs-core';
+import type { SidebarItem, AgentSession } from '../types.js';
+import type { SidebarContextValue } from '../context/SidebarContext.js';
+import type { SessionDataContextValue } from '../context/SessionContext.js';
+
+// Stub the two hooks the component reads. Each test installs its own
+// values via setSidebarValue / setSessionValue before rendering — this
+// avoids spinning up the full provider tree (which pulls live git
+// state, PR fetching, etc.).
+let sidebarValue: Partial<SidebarContextValue> = {};
+let sessionValue: Partial<SessionDataContextValue> = {};
+
+vi.mock('../context/SidebarContext.js', () => ({
+  useSidebar: () => sidebarValue,
+}));
+
+vi.mock('../context/SessionContext.js', () => ({
+  useSessionData: () => sessionValue,
+}));
+
+// Imported AFTER vi.mock — required so the mocks are wired in.
+const { SessionTabBar } = await import('./SessionTabBar.js');
+
+// ── Fixtures ─────────────────────────────────────────────────────
+
+function makeSession(name: string, running = true): AgentSession {
+  return { name, running };
+}
+
+function makeSessionItem(
+  name: string,
+  opts: { running?: boolean; pr?: PullRequestInfo } = {}
+): SidebarItem {
+  return {
+    kind: 'session',
+    session: makeSession(name, opts.running ?? true),
+    pr: opts.pr,
+    isMerged: false,
+  };
+}
+
+function makePr(id: number): PullRequestInfo {
+  return {
+    id,
+    title: `PR ${id}`,
+    sourceBranch: `branch-${id}`,
+    targetBranch: 'master',
+    url: `https://example.com/pr/${id}`,
+    createdByIdentifier: 'someone',
+    createdByDisplayName: 'Someone',
+  };
+}
+
+function setSidebar(items: SidebarItem[], selectedIndex = 0) {
+  sidebarValue = {
+    items,
+    selectedIndex,
+  };
+}
+
+function setSessions(prMap: Map<string, PullRequestInfo>) {
+  sessionValue = {
+    sessionPrMap: prMap,
+  };
+}
+
+beforeEach(() => {
+  sidebarValue = {};
+  sessionValue = {};
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('SessionTabBar', () => {
+  it('reserves an empty row when there are no running sessions', () => {
+    setSidebar([]);
+    setSessions(new Map());
+
+    const { lastFrame } = render(<SessionTabBar />);
+    const text = stripAnsi(lastFrame() ?? '').trim();
+    expect(text).toBe('');
+  });
+
+  it('skips non-session rows and stopped sessions', () => {
+    setSidebar([
+      makeSessionItem('alpha', { running: false }),
+      {
+        kind: 'orphan-pr',
+        pr: makePr(99),
+      },
+      makeSessionItem('beta', { running: true }),
+    ]);
+    setSessions(new Map());
+
+    const text = stripAnsi(render(<SessionTabBar />).lastFrame() ?? '');
+    expect(text).toContain('1 beta');
+    expect(text).not.toContain('alpha');
+    expect(text).not.toContain('#99');
+  });
+
+  it('renders #<prId> when the session has a PR', () => {
+    const pr123 = makePr(123);
+    setSidebar([
+      makeSessionItem('alpha', { running: true, pr: pr123 }),
+      makeSessionItem('beta', { running: true }),
+    ]);
+    setSessions(new Map([['alpha', pr123]]));
+
+    const text = stripAnsi(render(<SessionTabBar />).lastFrame() ?? '');
+    expect(text).toContain('1 #123');
+    expect(text).toContain('2 beta');
+  });
+
+  it('truncates long branch names with an ellipsis', () => {
+    setSidebar([
+      makeSessionItem('this-is-a-very-long-branch-name', { running: true }),
+    ]);
+    setSessions(new Map());
+
+    const text = stripAnsi(render(<SessionTabBar />).lastFrame() ?? '');
+    // 10-char cap with trailing ellipsis: "1 this-is-a…"
+    expect(text).toContain('1 this-is-a…');
+    expect(text).not.toContain('long-branch-name');
+  });
+
+  it('uses 0 as the digit for the 10th tab', () => {
+    const items = Array.from({ length: 10 }, (_, i) =>
+      makeSessionItem(`s${i + 1}`, { running: true })
+    );
+    setSidebar(items);
+    setSessions(new Map());
+
+    const text = stripAnsi(render(<SessionTabBar />).lastFrame() ?? '');
+    expect(text).toContain('9 s9');
+    expect(text).toContain('0 s10');
+  });
+
+  it('caps at 10 tabs and shows +N overflow indicator', () => {
+    const items = Array.from({ length: 13 }, (_, i) =>
+      makeSessionItem(`s${i + 1}`, { running: true })
+    );
+    setSidebar(items);
+    setSessions(new Map());
+
+    const text = stripAnsi(render(<SessionTabBar />).lastFrame() ?? '');
+    expect(text).toContain('0 s10');
+    expect(text).toContain('+3');
+    expect(text).not.toContain('s11');
+    expect(text).not.toContain('s13');
+  });
+
+  it('marks the currently-selected session tab with inverse styling', () => {
+    const items = [
+      makeSessionItem('alpha', { running: true }),
+      makeSessionItem('beta', { running: true }),
+      makeSessionItem('gamma', { running: true }),
+    ];
+    setSidebar(items, 1); // beta selected
+    setSessions(new Map());
+
+    const frame = render(<SessionTabBar />).lastFrame() ?? '';
+    // ANSI: ESC[7m turns inverse on, ESC[27m turns it off. The selected
+    // tab's segment should be wrapped in those, regardless of any color
+    // codes in between (cyan, etc.).
+    const ESC = String.fromCharCode(27);
+    const inverseOn = `${ESC}[7m`;
+    const inverseOff = `${ESC}[27m`;
+    const segments = frame.split(inverseOn).slice(1);
+    const inverseBeta = segments.some((seg) => {
+      const end = seg.indexOf(inverseOff);
+      return end !== -1 && seg.slice(0, end).includes('2 beta');
+    });
+    expect(inverseBeta).toBe(true);
+
+    // Sanity: alpha and gamma are NOT wrapped in inverse.
+    expect(stripAnsi(frame)).toContain('1 alpha');
+    expect(stripAnsi(frame)).toContain('3 gamma');
+  });
+});

--- a/apps/cli/src/components/SessionTabBar.tsx
+++ b/apps/cli/src/components/SessionTabBar.tsx
@@ -1,46 +1,40 @@
-import { useMemo } from 'react';
 import { Box, Text } from 'ink';
 import type { PullRequestInfo } from '@kirby/vcs-core';
-import { useSidebar } from '../context/SidebarContext.js';
 import { useSessionData } from '../context/SessionContext.js';
+import { useRunningTabs } from '../hooks/useRunningTabs.js';
 import { theme } from '../theme.js';
 import { getItemKey } from '../types.js';
-import type { SidebarItem } from '../types.js';
+import { useSidebar } from '../context/SidebarContext.js';
+import { tabDigit, type RunningSessionItem } from '../utils/running-tabs.js';
 
-type RunningSessionItem = Extract<SidebarItem, { kind: 'session' }>;
+const MAX_LABEL_CHARS = 16;
 
-const MAX_TABS = 10;
-const MAX_LABEL_CHARS = 10;
-
-function truncate(s: string, n: number): string {
-  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+function middleTruncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  const head = Math.ceil((max - 1) / 2);
+  const tail = Math.floor((max - 1) / 2);
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
 }
 
 function tabLabel(
-  index: number,
+  tabNumber: number,
   item: RunningSessionItem,
   pr: PullRequestInfo | undefined
 ): string {
-  const digit = index === 9 ? '0' : String(index + 1);
-  const body = pr ? `#${pr.id}` : truncate(item.session.name, MAX_LABEL_CHARS);
+  const digit = tabDigit(tabNumber);
+  const body = pr
+    ? `#${pr.id}`
+    : middleTruncate(item.session.name, MAX_LABEL_CHARS);
   return `${digit} ${body}`;
 }
 
 export function SessionTabBar() {
+  const { tabs, numbers } = useRunningTabs();
   const { items, selectedIndex } = useSidebar();
   const { sessionPrMap } = useSessionData();
 
-  const runningSessions = useMemo<RunningSessionItem[]>(
-    () =>
-      items.filter(
-        (it): it is RunningSessionItem =>
-          it.kind === 'session' && it.session.running
-      ),
-    [items]
-  );
-
-  const visibleTabs = runningSessions.slice(0, MAX_TABS);
-  const overflow = runningSessions.length - visibleTabs.length;
+  const visibleTabs = tabs.slice(0, 10);
+  const overflow = tabs.length - visibleTabs.length;
 
   const selectedItem = items[selectedIndex];
   const selectedKey = selectedItem ? getItemKey(selectedItem) : null;
@@ -53,17 +47,18 @@ export function SessionTabBar() {
 
   return (
     <Box flexDirection="row" height={1} paddingX={1}>
-      {visibleTabs.map((item, i) => {
+      {visibleTabs.map((item) => {
         const itemKey = getItemKey(item);
         const isActive = itemKey === selectedKey;
         const pr = sessionPrMap.get(item.session.name);
+        const tabNumber = numbers.get(item.session.name)!;
         return (
           <Box key={itemKey} marginRight={1}>
             <Text
               color={isActive ? theme.border.active : theme.border.inactive}
               inverse={isActive}
             >
-              {tabLabel(i, item, pr)}
+              {tabLabel(tabNumber, item, pr)}
             </Text>
           </Box>
         );

--- a/apps/cli/src/components/SessionTabBar.tsx
+++ b/apps/cli/src/components/SessionTabBar.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+import { Box, Text } from 'ink';
+import type { PullRequestInfo } from '@kirby/vcs-core';
+import { useSidebar } from '../context/SidebarContext.js';
+import { useSessionData } from '../context/SessionContext.js';
+import { theme } from '../theme.js';
+import { getItemKey } from '../types.js';
+import type { SidebarItem } from '../types.js';
+
+type RunningSessionItem = Extract<SidebarItem, { kind: 'session' }>;
+
+const MAX_TABS = 10;
+const MAX_LABEL_CHARS = 10;
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
+
+function tabLabel(
+  index: number,
+  item: RunningSessionItem,
+  pr: PullRequestInfo | undefined
+): string {
+  const digit = index === 9 ? '0' : String(index + 1);
+  const body = pr ? `#${pr.id}` : truncate(item.session.name, MAX_LABEL_CHARS);
+  return `${digit} ${body}`;
+}
+
+export function SessionTabBar() {
+  const { items, selectedIndex } = useSidebar();
+  const { sessionPrMap } = useSessionData();
+
+  const runningSessions = useMemo<RunningSessionItem[]>(
+    () =>
+      items.filter(
+        (it): it is RunningSessionItem =>
+          it.kind === 'session' && it.session.running
+      ),
+    [items]
+  );
+
+  const visibleTabs = runningSessions.slice(0, MAX_TABS);
+  const overflow = runningSessions.length - visibleTabs.length;
+
+  const selectedItem = items[selectedIndex];
+  const selectedKey = selectedItem ? getItemKey(selectedItem) : null;
+
+  // Always reserve the row (even empty) so PTY rows stay stable as
+  // sessions come and go — flicker is worse than a blank line.
+  if (visibleTabs.length === 0) {
+    return <Box height={1} />;
+  }
+
+  return (
+    <Box flexDirection="row" height={1} paddingX={1}>
+      {visibleTabs.map((item, i) => {
+        const itemKey = getItemKey(item);
+        const isActive = itemKey === selectedKey;
+        const pr = sessionPrMap.get(item.session.name);
+        return (
+          <Box key={itemKey} marginRight={1}>
+            <Text
+              color={isActive ? theme.border.active : theme.border.inactive}
+              inverse={isActive}
+            >
+              {tabLabel(i, item, pr)}
+            </Text>
+          </Box>
+        );
+      })}
+      {overflow > 0 && <Text color={theme.border.inactive}>+{overflow}</Text>}
+    </Box>
+  );
+}

--- a/apps/cli/src/components/Sidebar.tsx
+++ b/apps/cli/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import { useActivityStatus, useFlashPhase } from '../hooks/useActivity.js';
 import { noteSeen } from '../activity.js';
 import { remove as removeInactiveAlert } from '../inactive-alerts.js';
 import { LAYOUT } from '../context/LayoutContext.js';
+import { tabDigit } from '../utils/running-tabs.js';
 
 // ── Constants ───────────────────────────────────────────────────
 
@@ -83,6 +84,7 @@ const SessionItemRow = memo(function SessionItemRow({
   isMerged,
   conflictCount,
   vcsConfigured,
+  tabNumber,
 }: {
   session: AgentSession;
   selected: boolean;
@@ -91,6 +93,8 @@ const SessionItemRow = memo(function SessionItemRow({
   isMerged: boolean;
   conflictCount: number | undefined;
   vcsConfigured: boolean;
+  /** 1..10 if this session has a quick-switch tab; undefined otherwise. */
+  tabNumber: number | undefined;
 }) {
   // Single icon column: selected state (◉ ring) overrides, otherwise
   // running state (● filled green / ○ hollow gray). Saves 2 chars vs.
@@ -137,6 +141,11 @@ const SessionItemRow = memo(function SessionItemRow({
       <Box>
         <Box flexGrow={1} flexShrink={1} minWidth={0}>
           <Text wrap="truncate">
+            {tabNumber != null ? (
+              <Text color="cyan" bold>
+                {tabDigit(tabNumber)}{' '}
+              </Text>
+            ) : null}
             <Text color={iconColor}>{icon} </Text>
             {showFlash ? (
               <FlashingTitle bold={selected}>{title}</FlashingTitle>
@@ -272,6 +281,10 @@ export interface SidebarProps {
   focused: boolean;
   conflictsLoading?: boolean;
   hintsHidden?: boolean;
+  /** session-name → 1..10 quick-switch tab number for currently-running
+   *  sessions in the active-sessions tab bar. Sessions outside the
+   *  bar's 10-tab cap are absent from the map. */
+  tabNumbers: Map<string, number>;
 }
 
 export const Sidebar = memo(function Sidebar({
@@ -281,6 +294,7 @@ export const Sidebar = memo(function Sidebar({
   termRows,
   focused,
   hintsHidden = false,
+  tabNumbers,
 }: SidebarProps) {
   const { vcsConfigured } = useConfig();
   const keybinds = useKeybindResolve();
@@ -474,6 +488,7 @@ export const Sidebar = memo(function Sidebar({
           isMerged={item.isMerged}
           conflictCount={item.conflictCount}
           vcsConfigured={vcsConfigured}
+          tabNumber={tabNumbers.get(item.session.name)}
         />
       );
     }

--- a/apps/cli/src/context/LayoutContext.tsx
+++ b/apps/cli/src/context/LayoutContext.tsx
@@ -18,12 +18,17 @@ const PANE_BORDER_ROWS = 2; // top + bottom border
 // above-content title.
 const PANE_TITLE_ROWS = 0;
 const PANE_BORDER_COLS = 2; // left + right border
+// Active-sessions tab bar (SessionTabBar) sits at the top of the main
+// pane interior. Always reserved (even when empty) so the PTY size is
+// stable as sessions come and go.
+const TAB_BAR_ROWS = 1;
 
 export const LAYOUT = {
   SIDEBAR_WIDTH,
   PANE_BORDER_ROWS,
   PANE_TITLE_ROWS,
   PANE_BORDER_COLS,
+  TAB_BAR_ROWS,
 } as const;
 
 export interface TerminalLayout {
@@ -44,7 +49,10 @@ export function LayoutProvider({ children }: { children: ReactNode }) {
   const { rows: termRows, cols: termCols } = useTerminalDimensions();
 
   const paneCols = Math.max(20, termCols - SIDEBAR_WIDTH - PANE_BORDER_COLS);
-  const paneRows = Math.max(5, termRows - PANE_BORDER_ROWS - PANE_TITLE_ROWS);
+  const paneRows = Math.max(
+    5,
+    termRows - PANE_BORDER_ROWS - PANE_TITLE_ROWS - TAB_BAR_ROWS
+  );
 
   // One memo, not two — the outer object's identity only changes when
   // any of paneCols / paneRows / termRows / termCols changes, and

--- a/apps/cli/src/hooks/useRunningTabs.ts
+++ b/apps/cli/src/hooks/useRunningTabs.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import { useSidebar } from '../context/SidebarContext.js';
+import { getSpawnedAt } from '../pty-registry.js';
+import {
+  orderRunningTabs,
+  tabNumberMap,
+  type RunningSessionItem,
+} from '../utils/running-tabs.js';
+
+/**
+ * Active-sessions tab list, sorted by PTY spawn time, plus a name →
+ * tab-number lookup. Both the SessionTabBar and the Sidebar prefix
+ * read from this so the digits always agree.
+ *
+ * Reads `getSpawnedAt` directly from the PTY-registry module — the
+ * value is per-entry-immutable, and the set of running entries already
+ * propagates via React state (sidebar items rebuild when `running`
+ * flips), so re-running the memo on items change is enough.
+ */
+export function useRunningTabs(): {
+  tabs: RunningSessionItem[];
+  numbers: Map<string, number>;
+} {
+  const { items } = useSidebar();
+  return useMemo(() => {
+    const tabs = orderRunningTabs(items, getSpawnedAt);
+    const numbers = tabNumberMap(tabs);
+    return { tabs, numbers };
+  }, [items]);
+}

--- a/apps/cli/src/keybindings/registry.spec.ts
+++ b/apps/cli/src/keybindings/registry.spec.ts
@@ -44,7 +44,7 @@ function actionExists(id: string): boolean {
 function resolveInPreset(
   input: string,
   key: Key,
-  context: 'diff-file-list' | 'diff-viewer',
+  context: 'diff-file-list' | 'diff-viewer' | 'sidebar',
   preset: KeybindPreset
 ): string | null {
   return resolveAction(input, key, context, preset.bindings, ACTIONS);
@@ -267,5 +267,96 @@ describe('registry — diff-file-list comment actions', () => {
         ).toBeNull();
       }
     );
+  });
+});
+
+// ── Active-session tab switching ──────────────────────────────────
+//
+// Digits 1..9 + 0 (= tab 10) select the Nth running session in the
+// SessionTabBar and jump focus into the terminal. These tests lock
+// the digits → action ID mapping in both presets.
+
+describe('registry — sidebar.switch-tab-* (active-session tabs)', () => {
+  const tabIds: ActionId[] = [
+    'sidebar.switch-tab-1',
+    'sidebar.switch-tab-2',
+    'sidebar.switch-tab-3',
+    'sidebar.switch-tab-4',
+    'sidebar.switch-tab-5',
+    'sidebar.switch-tab-6',
+    'sidebar.switch-tab-7',
+    'sidebar.switch-tab-8',
+    'sidebar.switch-tab-9',
+    'sidebar.switch-tab-10',
+  ];
+
+  it.each(tabIds)('registers %s in ACTIONS', (id) => {
+    expect(actionExists(id)).toBe(true);
+  });
+
+  it.each(tabIds)('binds %s in Normie preset', (id) => {
+    expect(NORMIE_PRESET.bindings[id]?.length).toBeGreaterThan(0);
+  });
+
+  it.each(tabIds)('binds %s in Vim preset', (id) => {
+    expect(VIM_PRESET.bindings[id]?.length).toBeGreaterThan(0);
+  });
+
+  // Digit ↔ tab mapping (1..9 are sequential; 0 is tab 10)
+  const digitMap: { input: string; id: ActionId }[] = [
+    { input: '1', id: 'sidebar.switch-tab-1' },
+    { input: '2', id: 'sidebar.switch-tab-2' },
+    { input: '3', id: 'sidebar.switch-tab-3' },
+    { input: '4', id: 'sidebar.switch-tab-4' },
+    { input: '5', id: 'sidebar.switch-tab-5' },
+    { input: '6', id: 'sidebar.switch-tab-6' },
+    { input: '7', id: 'sidebar.switch-tab-7' },
+    { input: '8', id: 'sidebar.switch-tab-8' },
+    { input: '9', id: 'sidebar.switch-tab-9' },
+    { input: '0', id: 'sidebar.switch-tab-10' },
+  ];
+
+  describe('Normie preset digit mappings', () => {
+    it.each(digitMap)('$input → $id', ({ input, id }) => {
+      expect(resolveInPreset(input, makeKey(), 'sidebar', NORMIE_PRESET)).toBe(
+        id
+      );
+    });
+  });
+
+  describe('Vim preset digit mappings', () => {
+    it.each(digitMap)('$input → $id', ({ input, id }) => {
+      expect(resolveInPreset(input, makeKey(), 'sidebar', VIM_PRESET)).toBe(id);
+    });
+  });
+
+  // Conflict guard within sidebar context: each digit binding must
+  // resolve to exactly one action.
+  describe('no conflicts within sidebar context', () => {
+    it.each(digitMap)('Normie $input does not conflict', ({ input, id }) => {
+      expect(
+        findConflict(
+          input,
+          makeKey(),
+          'sidebar',
+          NORMIE_PRESET.bindings,
+          ACTIONS,
+          id
+        )
+      ).toBeNull();
+    });
+
+    it.each(digitMap)('Vim $input does not conflict', ({ input, id }) => {
+      expect(
+        findConflict(
+          input,
+          makeKey(),
+          'sidebar',
+          VIM_PRESET.bindings,
+          ACTIONS,
+          id
+        )
+      ).toBeNull();
+    });
   });
 });

--- a/apps/cli/src/keybindings/registry.ts
+++ b/apps/cli/src/keybindings/registry.ts
@@ -189,6 +189,62 @@ export const ACTIONS = [
     showInHints: true,
   },
 
+  // ── Active-session tab switching ──
+  // Bound to digits 1..9 and 0 (= tab 10). Selects the Nth running
+  // session in the active-sessions tab bar and jumps focus into the
+  // terminal in one shot. `showInHints: false` so the 10 entries don't
+  // blow the sidebar's keybind footer.
+  {
+    id: 'sidebar.switch-tab-1',
+    label: 'Switch to active tab 1',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-2',
+    label: 'Switch to active tab 2',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-3',
+    label: 'Switch to active tab 3',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-4',
+    label: 'Switch to active tab 4',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-5',
+    label: 'Switch to active tab 5',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-6',
+    label: 'Switch to active tab 6',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-7',
+    label: 'Switch to active tab 7',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-8',
+    label: 'Switch to active tab 8',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-9',
+    label: 'Switch to active tab 9',
+    context: 'sidebar',
+  },
+  {
+    id: 'sidebar.switch-tab-10',
+    label: 'Switch to active tab 10',
+    context: 'sidebar',
+  },
+
   // ── Settings ──
   {
     id: 'settings.navigate-down',
@@ -422,6 +478,18 @@ export const NORMIE_PRESET: KeybindPreset = {
     'sidebar.focus-terminal': [{ flags: { tab: true } }],
     'sidebar.toggle-hints': [{ input: '?' }],
 
+    // Active-session tab switching (digits, with 0 = tab 10)
+    'sidebar.switch-tab-1': [{ input: '1' }],
+    'sidebar.switch-tab-2': [{ input: '2' }],
+    'sidebar.switch-tab-3': [{ input: '3' }],
+    'sidebar.switch-tab-4': [{ input: '4' }],
+    'sidebar.switch-tab-5': [{ input: '5' }],
+    'sidebar.switch-tab-6': [{ input: '6' }],
+    'sidebar.switch-tab-7': [{ input: '7' }],
+    'sidebar.switch-tab-8': [{ input: '8' }],
+    'sidebar.switch-tab-9': [{ input: '9' }],
+    'sidebar.switch-tab-10': [{ input: '0' }],
+
     // Settings
     'settings.navigate-down': [{ flags: { downArrow: true } }],
     'settings.navigate-up': [{ flags: { upArrow: true } }],
@@ -517,6 +585,18 @@ export const VIM_PRESET: KeybindPreset = {
     'sidebar.start-session': [{ flags: { return: true } }],
     'sidebar.focus-terminal': [{ flags: { tab: true } }],
     'sidebar.toggle-hints': [{ input: '?' }],
+
+    // Active-session tab switching (digits, with 0 = tab 10)
+    'sidebar.switch-tab-1': [{ input: '1' }],
+    'sidebar.switch-tab-2': [{ input: '2' }],
+    'sidebar.switch-tab-3': [{ input: '3' }],
+    'sidebar.switch-tab-4': [{ input: '4' }],
+    'sidebar.switch-tab-5': [{ input: '5' }],
+    'sidebar.switch-tab-6': [{ input: '6' }],
+    'sidebar.switch-tab-7': [{ input: '7' }],
+    'sidebar.switch-tab-8': [{ input: '8' }],
+    'sidebar.switch-tab-9': [{ input: '9' }],
+    'sidebar.switch-tab-10': [{ input: '0' }],
 
     // Settings (same as normie — transient modal)
     'settings.navigate-down': [{ input: 'j' }, { flags: { downArrow: true } }],

--- a/apps/cli/src/pty-registry.ts
+++ b/apps/cli/src/pty-registry.ts
@@ -7,6 +7,12 @@ export interface PtyEntry {
   emu: TerminalEmulator;
   exited: boolean;
   exitCode?: number;
+  /** ms-since-epoch when this entry was added to the registry. Drives
+   *  the active-sessions tab bar's stable spawn-order sort. Restarting
+   *  a session via `spawnSession` (which kills the old entry first)
+   *  produces a fresh value, so the restarted tab moves to the end of
+   *  the bar — matching browser-tab semantics. */
+  spawnedAt: number;
 }
 
 const registry = new Map<string, PtyEntry>();
@@ -31,7 +37,7 @@ export function spawnSession(
 
   const pty = new PtySession(cmd, args, { cols, rows, cwd });
   const emu = new TerminalEmulator(cols, rows);
-  const entry: PtyEntry = { pty, emu, exited: false };
+  const entry: PtyEntry = { pty, emu, exited: false, spawnedAt: Date.now() };
 
   pty.onData((data) => {
     void emu.write(data);
@@ -53,6 +59,13 @@ export function getSession(name: string): PtyEntry | undefined {
 
 export function hasSession(name: string): boolean {
   return registry.has(name);
+}
+
+/** Return the spawn time (ms-since-epoch) for the named session, or
+ *  undefined if no PTY entry exists. Used by the tab bar's spawn-order
+ *  sort. Per-entry-immutable, so safe to read during render. */
+export function getSpawnedAt(name: string): number | undefined {
+  return registry.get(name)?.spawnedAt;
 }
 
 export function killSession(name: string): void {

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useInput } from 'ink';
+import { useInput, Box } from 'ink';
 import { Sidebar } from '../../components/Sidebar.js';
 import { Pane } from '../../components/Pane.js';
 import { SessionTabBar } from '../../components/SessionTabBar.js';
+import { useRunningTabs } from '../../hooks/useRunningTabs.js';
 import { useNavState, useNavActions } from '../../context/NavContext.js';
 import { useAsyncOps } from '../../context/AsyncOpsContext.js';
 import { useInactiveAlertWatcher } from '../../hooks/useInactiveAlertWatcher.js';
@@ -110,6 +111,7 @@ function MainTabBody({
   const configCtx = useConfig();
   const keybinds = useKeybinds();
   const sidebar = useSidebar();
+  const { numbers: tabNumbers } = useRunningTabs();
 
   const pane = usePaneReducer(
     sidebar.selectedItem,
@@ -238,19 +240,22 @@ function MainTabBody({
           termRows={layout.termRows}
           focused={sidebarFocused}
           hintsHidden={hintsHidden}
+          tabNumbers={tabNumbers}
         />
       )}
-      <Pane focused={mainFocused} title={paneTitle} flexGrow={1}>
+      <Box flexDirection="column" flexGrow={1}>
         <SessionTabBar />
-        <MainContent
-          pane={pane}
-          terminal={effectiveTerminal}
-          terminalFocused={terminalFocused}
-          sessionNameForTerminal={sidebar.sessionNameForTerminal}
-          selectedPr={sidebar.selectedPr}
-          onFocusSidebar={onTerminalEscape}
-        />
-      </Pane>
+        <Pane focused={mainFocused} title={paneTitle} flexGrow={1}>
+          <MainContent
+            pane={pane}
+            terminal={effectiveTerminal}
+            terminalFocused={terminalFocused}
+            sessionNameForTerminal={sidebar.sessionNameForTerminal}
+            selectedPr={sidebar.selectedPr}
+            onFocusSidebar={onTerminalEscape}
+          />
+        </Pane>
+      </Box>
     </>
   );
 }

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useInput } from 'ink';
 import { Sidebar } from '../../components/Sidebar.js';
 import { Pane } from '../../components/Pane.js';
+import { SessionTabBar } from '../../components/SessionTabBar.js';
 import { useNavState, useNavActions } from '../../context/NavContext.js';
 import { useAsyncOps } from '../../context/AsyncOpsContext.js';
 import { useInactiveAlertWatcher } from '../../hooks/useInactiveAlertWatcher.js';
@@ -240,6 +241,7 @@ function MainTabBody({
         />
       )}
       <Pane focused={mainFocused} title={paneTitle} flexGrow={1}>
+        <SessionTabBar />
         <MainContent
           pane={pane}
           terminal={effectiveTerminal}

--- a/apps/cli/src/screens/main/sidebar-input.spec.ts
+++ b/apps/cli/src/screens/main/sidebar-input.spec.ts
@@ -1,8 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Key } from 'ink';
-import { handleSidebarInput } from './sidebar-input.js';
 import type { SidebarInputCtx } from './input-types.js';
 import type { SidebarItem } from '../../types.js';
+
+// Mock the PTY registry — handleSidebarInput's tab-switch path now
+// orders running tabs by spawn time. The default `getSpawnedAt` mock
+// returns nothing; individual tests set spawnedAtMap to control order.
+let spawnedAtMap = new Map<string, number>();
+vi.mock('../../pty-registry.js', () => ({
+  getSpawnedAt: (name: string) => spawnedAtMap.get(name),
+  hasSession: () => false,
+  killSession: vi.fn(),
+}));
+
+const { handleSidebarInput } = await import('./sidebar-input.js');
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -40,6 +51,16 @@ function sessionItem(name: string, running = true): SidebarItem {
 }
 
 function buildCtx(items: SidebarItem[], action: string | null) {
+  // Default: assign spawn times in declared item order so existing
+  // tests' "Nth running session" assertions hold under spawn-order
+  // sort. Individual tests can override via setSpawnOrder.
+  spawnedAtMap = new Map();
+  let t = 1;
+  for (const item of items) {
+    if (item.kind === 'session' && item.session.running) {
+      spawnedAtMap.set(item.session.name, t++);
+    }
+  }
   const sidebar = {
     items,
     selectedIndex: 0,
@@ -154,6 +175,29 @@ describe('handleSidebarInput — sidebar.switch-tab-N', () => {
 
     expect(sidebar.selectByKey).toHaveBeenCalledExactlyOnceWith(
       'session:alpha'
+    );
+  });
+
+  it('uses spawn order, not items array order, for the digit lookup', () => {
+    // Items declared alpha → beta → gamma, but the user spawned them
+    // in a different order: gamma first, then alpha, then beta.
+    const items: SidebarItem[] = [
+      sessionItem('alpha', true),
+      sessionItem('beta', true),
+      sessionItem('gamma', true),
+    ];
+    const { ctx, sidebar } = buildCtx(items, 'sidebar.switch-tab-1');
+    spawnedAtMap = new Map([
+      ['gamma', 100],
+      ['alpha', 200],
+      ['beta', 300],
+    ]);
+
+    handleSidebarInput('1', makeKey(), ctx);
+
+    // Tab 1 = first-spawned = gamma
+    expect(sidebar.selectByKey).toHaveBeenCalledExactlyOnceWith(
+      'session:gamma'
     );
   });
 });

--- a/apps/cli/src/screens/main/sidebar-input.spec.ts
+++ b/apps/cli/src/screens/main/sidebar-input.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Key } from 'ink';
+import { handleSidebarInput } from './sidebar-input.js';
+import type { SidebarInputCtx } from './input-types.js';
+import type { SidebarItem } from '../../types.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeKey(): Key {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    return: false,
+    escape: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    pageDown: false,
+    pageUp: false,
+    home: false,
+    end: false,
+    ctrl: false,
+    shift: false,
+    meta: false,
+    super: false,
+    hyper: false,
+    capsLock: false,
+    numLock: false,
+  };
+}
+
+function sessionItem(name: string, running = true): SidebarItem {
+  return {
+    kind: 'session',
+    session: { name, running },
+    isMerged: false,
+  };
+}
+
+function buildCtx(items: SidebarItem[], action: string | null) {
+  const sidebar = {
+    items,
+    selectedIndex: 0,
+    selectedItem: items[0],
+    selectedPr: undefined,
+    sessionNameForTerminal: null,
+    totalItems: items.length,
+    selectByKey: vi.fn(),
+    moveSelection: vi.fn(),
+    moveSelectionToActive: vi.fn(),
+  };
+  const pane = {
+    setPaneMode: vi.fn(),
+    setReconnectKey: vi.fn(),
+  };
+  const nav = {
+    focus: 'sidebar' as const,
+    setFocus: vi.fn(),
+  };
+  const ctx = {
+    sidebar,
+    pane,
+    nav,
+    keybinds: {
+      resolve: vi.fn(() => action),
+    },
+    toggleHints: vi.fn(),
+    exit: vi.fn(),
+    // Unused fields below — cast via SidebarInputCtx forces the rest
+    // to be present at the type level, but the dispatch never reads
+    // them when the action is `sidebar.switch-tab-*`.
+    config: {} as never,
+    sessions: {} as never,
+    branchPicker: {} as never,
+    deleteConfirm: {} as never,
+    settings: {} as never,
+    asyncOps: {} as never,
+    terminal: {} as never,
+  } as unknown as SidebarInputCtx;
+
+  return { ctx, sidebar, pane, nav };
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('handleSidebarInput — sidebar.switch-tab-N', () => {
+  it('selects the Nth running session and jumps focus to terminal', () => {
+    const items: SidebarItem[] = [
+      sessionItem('alpha', true),
+      sessionItem('beta', false), // not running — skipped
+      sessionItem('gamma', true),
+      sessionItem('delta', true),
+    ];
+    const { ctx, sidebar, pane, nav } = buildCtx(items, 'sidebar.switch-tab-2');
+
+    handleSidebarInput('2', makeKey(), ctx);
+
+    // 1st running = alpha, 2nd running = gamma → switch-tab-2 selects gamma
+    expect(sidebar.selectByKey).toHaveBeenCalledExactlyOnceWith(
+      'session:gamma'
+    );
+    expect(pane.setPaneMode).toHaveBeenCalledExactlyOnceWith('terminal');
+    expect(pane.setReconnectKey).toHaveBeenCalledOnce();
+    expect(nav.setFocus).toHaveBeenCalledExactlyOnceWith('terminal');
+  });
+
+  it('treats 0 as tab 10', () => {
+    const items: SidebarItem[] = Array.from({ length: 12 }, (_, i) =>
+      sessionItem(`s${i + 1}`, true)
+    );
+    const { ctx, sidebar } = buildCtx(items, 'sidebar.switch-tab-10');
+
+    handleSidebarInput('0', makeKey(), ctx);
+
+    expect(sidebar.selectByKey).toHaveBeenCalledExactlyOnceWith('session:s10');
+  });
+
+  it('does nothing when the requested tab index has no running session', () => {
+    const items: SidebarItem[] = [
+      sessionItem('alpha', true),
+      sessionItem('beta', true),
+    ];
+    const { ctx, sidebar, pane, nav } = buildCtx(items, 'sidebar.switch-tab-5');
+
+    handleSidebarInput('5', makeKey(), ctx);
+
+    expect(sidebar.selectByKey).not.toHaveBeenCalled();
+    expect(pane.setPaneMode).not.toHaveBeenCalled();
+    expect(nav.setFocus).not.toHaveBeenCalled();
+  });
+
+  it('skips orphan-pr / review-pr rows when counting tabs', () => {
+    const items: SidebarItem[] = [
+      {
+        kind: 'orphan-pr',
+        pr: {
+          id: 1,
+          title: 'orphan',
+          sourceBranch: 'o',
+          targetBranch: 'master',
+          url: '',
+          createdByIdentifier: '',
+          createdByDisplayName: '',
+        },
+      },
+      sessionItem('alpha', true),
+      sessionItem('beta', true),
+    ];
+    const { ctx, sidebar } = buildCtx(items, 'sidebar.switch-tab-1');
+
+    handleSidebarInput('1', makeKey(), ctx);
+
+    expect(sidebar.selectByKey).toHaveBeenCalledExactlyOnceWith(
+      'session:alpha'
+    );
+  });
+});

--- a/apps/cli/src/screens/main/sidebar-input.ts
+++ b/apps/cli/src/screens/main/sidebar-input.ts
@@ -8,8 +8,9 @@ import {
   branchToSessionName,
   rebaseOntoMaster,
 } from '@kirby/worktree-manager';
-import { hasSession, killSession } from '../../pty-registry.js';
+import { getSpawnedAt, hasSession, killSession } from '../../pty-registry.js';
 import { getItemKey, getPrFromItem } from '../../types.js';
+import { orderRunningTabs } from '../../utils/running-tabs.js';
 import type { SidebarInputCtx } from './input-types.js';
 import { startAiSession } from './branch-picker-input.js';
 import { resolveEditorTarget } from './editor-target.js';
@@ -80,15 +81,15 @@ export function handleSidebarInput(
   }
 
   // Active-session tab switch (digits 1..9, 0 = tab 10)
-  // Selects the Nth running session in sidebar order and jumps focus
-  // straight into the terminal — mirrors the focus-terminal happy path
-  // above (setPaneMode + setReconnectKey + setFocus).
+  // Selects the Nth running session in spawn-time order so the digit
+  // matches what's shown in the SessionTabBar and the sidebar prefix.
+  // Then jumps focus straight into the terminal — mirrors the
+  // focus-terminal happy path above (setPaneMode + setReconnectKey +
+  // setFocus).
   const tabMatch = action?.match(/^sidebar\.switch-tab-(\d+)$/);
   if (tabMatch) {
     const n = Number(tabMatch[1]);
-    const target = ctx.sidebar.items.filter(
-      (it) => it.kind === 'session' && it.session.running
-    )[n - 1];
+    const target = orderRunningTabs(ctx.sidebar.items, getSpawnedAt)[n - 1];
     if (target) {
       ctx.sidebar.selectByKey(getItemKey(target));
       ctx.pane.setPaneMode('terminal');

--- a/apps/cli/src/screens/main/sidebar-input.ts
+++ b/apps/cli/src/screens/main/sidebar-input.ts
@@ -9,7 +9,7 @@ import {
   rebaseOntoMaster,
 } from '@kirby/worktree-manager';
 import { hasSession, killSession } from '../../pty-registry.js';
-import { getPrFromItem } from '../../types.js';
+import { getItemKey, getPrFromItem } from '../../types.js';
 import type { SidebarInputCtx } from './input-types.js';
 import { startAiSession } from './branch-picker-input.js';
 import { resolveEditorTarget } from './editor-target.js';
@@ -75,6 +75,25 @@ export function handleSidebarInput(
       });
     } else if (ctx.nav.focus === 'terminal') {
       ctx.nav.setFocus('sidebar');
+    }
+    return;
+  }
+
+  // Active-session tab switch (digits 1..9, 0 = tab 10)
+  // Selects the Nth running session in sidebar order and jumps focus
+  // straight into the terminal — mirrors the focus-terminal happy path
+  // above (setPaneMode + setReconnectKey + setFocus).
+  const tabMatch = action?.match(/^sidebar\.switch-tab-(\d+)$/);
+  if (tabMatch) {
+    const n = Number(tabMatch[1]);
+    const target = ctx.sidebar.items.filter(
+      (it) => it.kind === 'session' && it.session.running
+    )[n - 1];
+    if (target) {
+      ctx.sidebar.selectByKey(getItemKey(target));
+      ctx.pane.setPaneMode('terminal');
+      ctx.pane.setReconnectKey((k) => k + 1);
+      ctx.nav.setFocus('terminal');
     }
     return;
   }

--- a/apps/cli/src/utils/running-tabs.spec.ts
+++ b/apps/cli/src/utils/running-tabs.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import type { SidebarItem } from '../types.js';
+import { orderRunningTabs, tabNumberMap, tabDigit } from './running-tabs.js';
+
+function sessionItem(name: string, running = true): SidebarItem {
+  return {
+    kind: 'session',
+    session: { name, running },
+    isMerged: false,
+  };
+}
+
+describe('orderRunningTabs', () => {
+  it('returns running sessions sorted by spawn time, ascending', () => {
+    const items: SidebarItem[] = [
+      sessionItem('alpha'),
+      sessionItem('beta'),
+      sessionItem('gamma'),
+    ];
+    const spawnedAt = new Map<string, number>([
+      ['alpha', 300],
+      ['beta', 100],
+      ['gamma', 200],
+    ]);
+
+    const ordered = orderRunningTabs(items, (n) => spawnedAt.get(n));
+
+    expect(ordered.map((it) => it.session.name)).toEqual([
+      'beta',
+      'gamma',
+      'alpha',
+    ]);
+  });
+
+  it('skips non-running sessions and non-session rows', () => {
+    const items: SidebarItem[] = [
+      sessionItem('alive'),
+      sessionItem('dead', false),
+      {
+        kind: 'orphan-pr',
+        pr: {
+          id: 1,
+          title: 'orphan',
+          sourceBranch: 'o',
+          targetBranch: 'master',
+          url: '',
+          createdByIdentifier: '',
+          createdByDisplayName: '',
+        },
+      },
+    ];
+    const ordered = orderRunningTabs(items, () => 100);
+    expect(ordered.map((it) => it.session.name)).toEqual(['alive']);
+  });
+
+  it('sessions without a spawn time sort to the end', () => {
+    const items: SidebarItem[] = [
+      sessionItem('orphan-spawn'),
+      sessionItem('first'),
+      sessionItem('second'),
+    ];
+    const spawnedAt = new Map<string, number>([
+      ['first', 100],
+      ['second', 200],
+    ]);
+    const ordered = orderRunningTabs(items, (n) => spawnedAt.get(n));
+    expect(ordered.map((it) => it.session.name)).toEqual([
+      'first',
+      'second',
+      'orphan-spawn',
+    ]);
+  });
+
+  it('preserves spawn order across kill+restart (restart bumps to end)', () => {
+    // Initial state: a (t=100), b (t=200), c (t=300) → a,b,c.
+    // User kills c then restarts it → c gets a fresh spawnedAt (t=400).
+    // Expected order: a, b, c (unchanged because c was already last).
+    // Now user kills+restarts a → fresh t=500. Expected: b, c, a.
+    const items: SidebarItem[] = [
+      sessionItem('a'),
+      sessionItem('b'),
+      sessionItem('c'),
+    ];
+    const spawnedAt = new Map<string, number>([
+      ['b', 200],
+      ['c', 400],
+      ['a', 500],
+    ]);
+    const ordered = orderRunningTabs(items, (n) => spawnedAt.get(n));
+    expect(ordered.map((it) => it.session.name)).toEqual(['b', 'c', 'a']);
+  });
+});
+
+describe('tabNumberMap', () => {
+  it('maps the first 10 tabs to numbers 1..10', () => {
+    const ordered = Array.from({ length: 12 }, (_, i) =>
+      sessionItem(`s${i + 1}`)
+    ) as Extract<SidebarItem, { kind: 'session' }>[];
+    const map = tabNumberMap(ordered);
+    expect(map.get('s1')).toBe(1);
+    expect(map.get('s9')).toBe(9);
+    expect(map.get('s10')).toBe(10);
+    expect(map.has('s11')).toBe(false);
+    expect(map.has('s12')).toBe(false);
+  });
+});
+
+describe('tabDigit', () => {
+  it('renders 1..9 as themselves and 10 as "0"', () => {
+    expect(tabDigit(1)).toBe('1');
+    expect(tabDigit(5)).toBe('5');
+    expect(tabDigit(9)).toBe('9');
+    expect(tabDigit(10)).toBe('0');
+  });
+});

--- a/apps/cli/src/utils/running-tabs.ts
+++ b/apps/cli/src/utils/running-tabs.ts
@@ -1,0 +1,55 @@
+import type { SidebarItem } from '../types.js';
+
+export type RunningSessionItem = Extract<SidebarItem, { kind: 'session' }>;
+
+const MAX_TABS = 10;
+
+/**
+ * Return all running session rows from the sidebar items list, sorted
+ * ascending by PTY spawn time. Sessions whose PTY entry isn't found
+ * (race window between `running` flipping and the registry read) sort
+ * to the end via Infinity — they'd land at the end anyway.
+ *
+ * Pure: no React state, no module side-effects. The `spawnedAt` lookup
+ * is passed in (typically `getSpawnedAt` from `pty-registry`).
+ */
+export function orderRunningTabs(
+  items: SidebarItem[],
+  spawnedAt: (name: string) => number | undefined
+): RunningSessionItem[] {
+  return items
+    .filter(
+      (it): it is RunningSessionItem =>
+        it.kind === 'session' && it.session.running
+    )
+    .sort((a, b) => {
+      const tA = spawnedAt(a.session.name) ?? Number.POSITIVE_INFINITY;
+      const tB = spawnedAt(b.session.name) ?? Number.POSITIVE_INFINITY;
+      return tA - tB;
+    });
+}
+
+/**
+ * Map session name → 1-indexed tab number, capped at the first 10
+ * tabs (digits 1..9 then 0 = tab 10). Sessions outside the cap are
+ * absent from the map. Consumed by both the tab bar (for highlight)
+ * and the sidebar (for the digit prefix on each row).
+ */
+export function tabNumberMap(
+  orderedTabs: RunningSessionItem[]
+): Map<string, number> {
+  const map = new Map<string, number>();
+  orderedTabs.slice(0, MAX_TABS).forEach((item, i) => {
+    map.set(item.session.name, i + 1);
+  });
+  return map;
+}
+
+/**
+ * Convert a 1..10 tab number to the digit shown in the UI: tab 10 is
+ * displayed as "0" so it can be reached with the 0 key (no two-digit
+ * keys allowed in single-keystroke quick-switch).
+ */
+export function tabDigit(tabNumber: number): string {
+  return tabNumber === MAX_TABS ? '0' : String(tabNumber);
+}


### PR DESCRIPTION
DRAFT

ctrl+space, then a number to switch fast between active tabs (shown as tabs above the agent)