### PR TITLE
fix: prevent git commands from prompting for credentials

### DIFF
--- a/apps/cli/src/hooks/useDiffData.ts
+++ b/apps/cli/src/hooks/useDiffData.ts
@@ -7,6 +7,15 @@ import { beginOp } from './useAsyncOperation.js';
 
 const execFile = promisify(execFileCb);
 
+/**
+ * Environment variables that prevent git/SSH from prompting for auth.
+ * Mirrors the same constant in @kirby/worktree-manager's exec.ts.
+ */
+const GIT_NO_PROMPT_ENV = {
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
+};
+
 function mapNameStatus(letter: string): DiffFile['status'] {
   const code = letter.charAt(0);
   switch (code) {
@@ -73,6 +82,7 @@ export async function fetchAllFiles(
       ? Promise.resolve()
       : execFile('git', ['fetch', 'origin', sourceBranch], {
           timeout: 30_000,
+          env: { ...process.env, ...GIT_NO_PROMPT_ENV },
         }).catch(() => {
           /* branch may already exist locally */
         }),
@@ -80,6 +90,7 @@ export async function fetchAllFiles(
       ? Promise.resolve()
       : execFile('git', ['fetch', 'origin', targetBranch], {
           timeout: 30_000,
+          env: { ...process.env, ...GIT_NO_PROMPT_ENV },
         })
           .then(() => {
             targetFetchedAt.set(targetBranch, Date.now());

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -16,12 +16,6 @@
   ],
   "references": [
     {
-      "path": "../../libs/diff/tsconfig.lib.json"
-    },
-    {
-      "path": "../../libs/review-comments/tsconfig.lib.json"
-    },
-    {
       "path": "../../libs/worktree-manager/tsconfig.lib.json"
     },
     {

--- a/libs/review-comments/tsconfig.lib.json
+++ b/libs/review-comments/tsconfig.lib.json
@@ -12,12 +12,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../vcs/core/tsconfig.lib.json"
-    },
-    {
-      "path": "../diff/tsconfig.lib.json"
-    },
-    {
       "path": "../logger/tsconfig.lib.json"
     }
   ],

--- a/libs/worktree-manager/src/index.ts
+++ b/libs/worktree-manager/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/worktree.js';
+export { GIT_NO_PROMPT_ENV } from './lib/exec.js';

--- a/libs/worktree-manager/src/lib/exec.ts
+++ b/libs/worktree-manager/src/lib/exec.ts
@@ -1,4 +1,29 @@
-import { exec as execCb } from 'node:child_process';
+import { exec as execCb, type ExecOptions } from 'node:child_process';
 import { promisify } from 'node:util';
 
-export const exec = promisify(execCb);
+const execAsync = promisify(execCb);
+
+/** Default timeout for git commands (30s). */
+const GIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Environment variables that prevent git and SSH from prompting for
+ * credentials interactively. Without these, a locked SSH agent (e.g.
+ * 1Password) can cause SSH to open /dev/tty for a passphrase prompt,
+ * which steals stdin from Kirby's TUI.
+ */
+export const GIT_NO_PROMPT_ENV = {
+  GIT_TERMINAL_PROMPT: '0', // git: never prompt for credentials
+  GIT_SSH_COMMAND: 'ssh -o BatchMode=yes', // ssh: never prompt on TTY
+};
+
+export function exec(
+  command: string,
+  options?: { encoding: BufferEncoding } & ExecOptions
+): Promise<{ stdout: string; stderr: string }> {
+  return execAsync(command, {
+    timeout: GIT_TIMEOUT_MS,
+    ...options,
+    env: { ...process.env, ...GIT_NO_PROMPT_ENV, ...options?.env },
+  });
+}


### PR DESCRIPTION
## Problem

When the SSH agent (e.g. 1Password) is locked, SSH may open `/dev/tty` to prompt for a passphrase. Since Kirby renders its TUI over stdin, this hidden prompt captures all keyboard input, making the app appear frozen.

## Fix

Set environment variables on all git exec calls:

- `GIT_SSH_COMMAND="ssh -o BatchMode=yes"` — prevents SSH from opening /dev/tty for interactive prompts
- `GIT_TERMINAL_PROMPT=0` — prevents git's own credential helpers from prompting (covers HTTPS repos)
- 30s exec timeout — kills stalled processes as a last resort

## Scope

- **`libs/worktree-manager/src/lib/exec.ts`** — wraps all git commands (fetchRemote, fastForwardMainBranch, rebaseOntoMaster, etc.)
- **`apps/cli/src/hooks/useDiffData.ts`** — direct `execFile` calls for `git fetch` in the diff viewer

Also includes stale tsconfig reference cleanup from `nx sync`.