### PR TITLE
fix: show detached-HEAD worktrees in sidebar and allow starting sessions

### DIFF
--- a/apps/cli-e2e/src/detached-head.test.ts
+++ b/apps/cli-e2e/src/detached-head.test.ts
@@ -1,0 +1,61 @@
+import { execSync } from 'node:child_process';
+import { test, expect } from './fixtures/kirby.js';
+import { createTestRepo, registerCleanup } from './setup/git-repo.js';
+import { sidebarLocator } from './setup/sidebar.js';
+
+// ── Module-scope setup ─────────────────────────────────────────────
+// A repo with a detached-HEAD worktree under .claude/worktrees/. The
+// worktree directory name (no branch) is what should drive the session.
+const WORKTREE_NAME = 'master-test-temp';
+
+const repoDir = createTestRepo();
+registerCleanup(repoDir);
+execSync(
+  `git worktree add --detach ".claude/worktrees/${WORKTREE_NAME}" HEAD`,
+  { cwd: repoDir, stdio: 'pipe' }
+);
+
+test.use({
+  kirbyRepoPath: repoDir,
+  kirbyConfig: {
+    aiCommand: 'echo kirby-detached-active && sleep 300',
+    keybindPreset: 'vim',
+  },
+});
+
+test.describe('Detached-HEAD worktree', () => {
+  // Repro: a worktree whose HEAD is detached has no branch, so
+  // `git worktree list --porcelain` emits a `detached` marker instead
+  // of a `branch refs/heads/...` line. Pre-fix the session name was
+  // derived as `branchToSessionName('') === ''`, rendering a blank
+  // sidebar row and breaking the worktree lookup that starts a session.
+  test('appears in the sidebar by its directory name', async ({ kirby }) => {
+    await expect(kirby.term.getByText('Kirby').first()).toBeVisible();
+
+    // The detached worktree is the only session — it must show up by
+    // its directory name. Pre-fix the row title was an empty string
+    // (branchToSessionName('')), so this text never appeared.
+    await expect(
+      sidebarLocator(kirby.term.page, WORKTREE_NAME).any()
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('can start a session in it', async ({ kirby }) => {
+    await expect(
+      sidebarLocator(kirby.term.page, WORKTREE_NAME).any()
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The only row is auto-selected. Tab starts the PTY and focuses the
+    // terminal. Pre-fix the worktree lookup failed (empty name mismatch)
+    // so no PTY ever spawned.
+    await kirby.term.press('Tab');
+    await expect(
+      kirby.term.getByText('ctrl+space to exit').first()
+    ).toBeVisible({ timeout: 10_000 });
+
+    // The agent ran in the worktree → its banner is on screen.
+    await expect(
+      kirby.term.getByText('kirby-detached-active').first()
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/apps/cli/src/hooks/useSessionManager.ts
+++ b/apps/cli/src/hooks/useSessionManager.ts
@@ -4,7 +4,7 @@ import {
   deleteBranch,
   listAllBranches,
   listWorktrees,
-  branchToSessionName,
+  worktreeSessionName,
   setWorktreeResolver,
   createTemplateResolver,
 } from '@kirby/worktree-manager';
@@ -25,7 +25,7 @@ export function useSessionManager(
     const worktrees = await listWorktrees();
     const filtered: AgentSession[] = [];
     for (const wt of worktrees) {
-      const name = branchToSessionName(wt.branch);
+      const name = worktreeSessionName(wt);
       filtered.push({
         name,
         running: hasPtySession(name),

--- a/apps/cli/src/screens/main/editor-target.ts
+++ b/apps/cli/src/screens/main/editor-target.ts
@@ -1,5 +1,6 @@
 import {
   branchToSessionName,
+  worktreeSessionName,
   type WorktreeInfo,
 } from '@kirby/worktree-manager';
 import type { SidebarItem } from '../../types.js';
@@ -32,7 +33,7 @@ export async function resolveEditorTarget(
 
   const worktrees = await deps.listWorktrees();
   const existing = worktrees.find(
-    (w) => branchToSessionName(w.branch) === sessionName
+    (w) => worktreeSessionName(w) === sessionName
   );
   if (existing) return existing.path;
 

--- a/apps/cli/src/screens/main/sidebar-input.ts
+++ b/apps/cli/src/screens/main/sidebar-input.ts
@@ -6,6 +6,7 @@ import {
   listAllBranches,
   listWorktrees,
   branchToSessionName,
+  worktreeSessionName,
   rebaseOntoMaster,
 } from '@kirby/worktree-manager';
 import { hasSession, killSession } from '../../pty-registry.js';
@@ -47,7 +48,7 @@ export function handleSidebarInput(
         if (selectedItem.kind === 'session') {
           const worktrees = await listWorktrees();
           const wt = worktrees.find(
-            (w) => branchToSessionName(w.branch) === selectedItem.session.name
+            (w) => worktreeSessionName(w) === selectedItem.session.name
           );
           if (!wt) return;
           startAiSession(
@@ -110,9 +111,7 @@ export function handleSidebarInput(
         : branchToSessionName(selectedItem.pr.sourceBranch);
     ctx.asyncOps.run('check-delete', async () => {
       const worktrees = await listWorktrees();
-      const wt = worktrees.find(
-        (w) => branchToSessionName(w.branch) === sessionName
-      );
+      const wt = worktrees.find((w) => worktreeSessionName(w) === sessionName);
       const branch = wt?.branch;
       if (branch) {
         const check = await canRemoveBranch(branch);
@@ -196,9 +195,7 @@ export function handleSidebarInput(
     const sessionName = selectedItem.session.name;
     ctx.asyncOps.run('rebase', async () => {
       const worktrees = await listWorktrees();
-      const wt = worktrees.find(
-        (w) => branchToSessionName(w.branch) === sessionName
-      );
+      const wt = worktrees.find((w) => worktreeSessionName(w) === sessionName);
       if (!wt) {
         ctx.sessions.flashStatus('No worktree found for selected session');
         return;
@@ -309,7 +306,7 @@ export function handleSidebarInput(
       ctx.asyncOps.run('start-session', async () => {
         const worktrees = await listWorktrees();
         const wt = worktrees.find(
-          (w) => branchToSessionName(w.branch) === selectedItem.session.name
+          (w) => worktreeSessionName(w) === selectedItem.session.name
         );
         if (!wt) return;
         startAiSession(

--- a/libs/worktree-manager/src/lib/worktree.spec.ts
+++ b/libs/worktree-manager/src/lib/worktree.spec.ts
@@ -17,6 +17,7 @@ import {
   resetMainBranchCache,
   resetWorktreeResolver,
   branchToSessionName,
+  worktreeSessionName,
   setWorktreeResolver,
   createTemplateResolver,
 } from './worktree.js';
@@ -263,6 +264,30 @@ describe('parseWorktrees', () => {
     expect(result[2]).toEqual({
       path: '/home/user/repo/.claude/worktrees/fix-bug',
       branch: 'fix/bug',
+      bare: false,
+    });
+  });
+
+  it('should parse a detached-HEAD worktree with an empty branch', () => {
+    // A detached worktree has no `branch refs/heads/...` line — git
+    // emits a `detached` marker instead. The block must still be
+    // returned (with branch === '') so it shows up in the sidebar.
+    const output = [
+      'worktree /home/user/repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /home/user/repo/.claude/worktrees/master-test-temp',
+      'HEAD f6d61737bd',
+      'detached',
+      '',
+    ].join('\n');
+
+    const result = parseWorktrees(output);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual({
+      path: '/home/user/repo/.claude/worktrees/master-test-temp',
+      branch: '',
       bare: false,
     });
   });
@@ -663,6 +688,28 @@ describe('branchToSessionName', () => {
 
   it('should handle empty string', () => {
     expect(branchToSessionName('')).toBe('');
+  });
+});
+
+describe('worktreeSessionName', () => {
+  it('uses the branch-derived name when a branch is present', () => {
+    expect(
+      worktreeSessionName({
+        path: '/repo/.claude/worktrees/feature-auth',
+        branch: 'feature/auth',
+        bare: false,
+      })
+    ).toBe('feature-auth');
+  });
+
+  it('falls back to the directory name for a detached worktree', () => {
+    expect(
+      worktreeSessionName({
+        path: '/repo/.claude/worktrees/master-test-temp',
+        branch: '',
+        bare: false,
+      })
+    ).toBe('master-test-temp');
   });
 });
 

--- a/libs/worktree-manager/src/lib/worktree.ts
+++ b/libs/worktree-manager/src/lib/worktree.ts
@@ -5,7 +5,7 @@
  * used by the TUI to give each Claude session its own checkout.
  */
 import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 import { log } from '@kirby/logger';
 import { exec } from './exec.js';
 
@@ -103,6 +103,19 @@ export interface WorktreeInfo {
 /** Convert a git branch name to a safe session identifier (replace / with -) */
 export function branchToSessionName(branch: string): string {
   return branch.replace(/\//g, '-');
+}
+
+/**
+ * Stable session name for a worktree.
+ *
+ * Branch worktrees use the branch-derived name. A detached-HEAD
+ * worktree has no branch, so we fall back to its directory name —
+ * without this fallback `branchToSessionName('')` yields an empty
+ * string, which renders as a blank sidebar row and can't be matched
+ * back to its worktree to start a session.
+ */
+export function worktreeSessionName(wt: WorktreeInfo): string {
+  return wt.branch ? branchToSessionName(wt.branch) : basename(wt.path);
 }
 
 /** Convert a branch name to its worktree relative directory */


### PR DESCRIPTION
## Problem

A worktree whose HEAD is **detached** (e.g. `…/.claude/worktrees/master-test-temp f6d61737bd (detached HEAD)`) did not show up in Kirby's sidebar, and a session could not be started in it.

`git worktree list --porcelain` describes a detached worktree with a `detached` marker and **no** `branch refs/heads/…` line:

```
worktree /…/.claude/worktrees/master-test-temp
HEAD f6d61737bd…
detached
```

`parseWorktrees` only reads the `branch` line, so `branch` was left empty and `branchToSessionName('')` produced an **empty session name**. The row title is `pr?.title || session.name`, so it rendered blank, and the worktree lookup that starts a session (`branchToSessionName(w.branch) === session.name`) couldn't match it.

## Fix

Add a single source of truth in `worktree-manager`:

```ts
export function worktreeSessionName(wt: WorktreeInfo): string {
  return wt.branch ? branchToSessionName(wt.branch) : basename(wt.path);
}
```

A detached worktree falls back to its **directory name**. Replaced `branchToSessionName(w.branch)` with `worktreeSessionName(w)` at every worktree-derive/match site (`useSessionManager`, `sidebar-input`, `editor-target`). PR `sourceBranch` callers keep `branchToSessionName` — those are real branch names. `branch` itself stays `''` for detached worktrees, so the delete path correctly degrades to "no branch to delete".

## Tests

- **Unit** (`worktree.spec.ts`): a `parseWorktrees` case for detached porcelain output → `branch: ''`, plus a `worktreeSessionName` block (branch vs. directory-name fallback).
- **E2E** (`apps/cli-e2e/src/detached-head.test.ts`, new): builds a repo with a `--detach` worktree under `.claude/worktrees/`, asserts the row appears by its directory name and that a session starts in it.

Verified red/green: both e2e tests **fail** without the fix and **pass** with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
