### PR TITLE
fix: detect agent exit and update sidebar running state

### DIFF
--- a/apps/cli/src/hooks/useSessionManager.ts
+++ b/apps/cli/src/hooks/useSessionManager.ts
@@ -11,7 +11,12 @@ import {
 import type { AgentSession } from '../types.js';
 import { readConfig, autoDetectProjectConfig } from '@kirby/vcs-core';
 import type { VcsProvider } from '@kirby/vcs-core';
-import { killSession, hasSession as hasPtySession } from '../pty-registry.js';
+import {
+  killSession,
+  hasSession as hasPtySession,
+  onSessionExit,
+  offSessionExit,
+} from '../pty-registry.js';
 
 export function useSessionManager(
   providers: VcsProvider[],
@@ -73,6 +78,15 @@ export function useSessionManager(
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Re-derive running state when any PTY process exits on its own
+  useEffect(() => {
+    const handleExit = () => {
+      void refreshSessions();
+    };
+    onSessionExit(handleExit);
+    return () => offSessionExit(handleExit);
+  }, [refreshSessions]);
 
   return {
     sessions,

--- a/apps/cli/src/pty-registry.spec.ts
+++ b/apps/cli/src/pty-registry.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Capture the onExit callback registered by spawnSession
+let capturedOnExit: ((code: number, signal?: number) => void) | null = null;
+
+vi.mock('@kirby/terminal', () => ({
+  PtySession: class MockPtySession {
+    onData = vi.fn();
+    onExit = vi.fn((cb: (code: number, signal?: number) => void) => {
+      capturedOnExit = cb;
+    });
+    dispose = vi.fn();
+    resize = vi.fn();
+    write = vi.fn();
+    pid = 1234;
+    cols = 80;
+    rows = 24;
+  },
+  TerminalEmulator: class MockTerminalEmulator {
+    write = vi.fn();
+    render = vi.fn(() => '');
+    resize = vi.fn();
+    dispose = vi.fn();
+    onRender = vi.fn();
+    offRender = vi.fn();
+  },
+}));
+vi.mock('./activity.js', () => ({
+  attach: vi.fn(),
+  detach: vi.fn(),
+}));
+vi.mock('./inactive-alerts.js', () => ({
+  remove: vi.fn(),
+}));
+
+import {
+  spawnSession,
+  getSession,
+  hasSession,
+  killSession,
+  onSessionExit,
+  offSessionExit,
+} from './pty-registry.js';
+
+beforeEach(() => {
+  capturedOnExit = null;
+});
+
+afterEach(() => {
+  killSession('test-session');
+});
+
+describe('pty-registry', () => {
+  describe('hasSession reflects process exit', () => {
+    it('returns true for a running session', () => {
+      spawnSession('test-session', '/bin/sh', ['-c', 'true'], 80, 24, '/tmp');
+      expect(hasSession('test-session')).toBe(true);
+    });
+
+    it('returns false after the process exits on its own', () => {
+      spawnSession('test-session', '/bin/sh', ['-c', 'true'], 80, 24, '/tmp');
+      expect(hasSession('test-session')).toBe(true);
+
+      // Simulate the process exiting on its own
+      capturedOnExit!(0);
+
+      expect(hasSession('test-session')).toBe(false);
+    });
+
+    it('getSession still returns the entry after exit (for terminal rendering)', () => {
+      spawnSession('test-session', '/bin/sh', ['-c', 'true'], 80, 24, '/tmp');
+      capturedOnExit!(1);
+
+      const entry = getSession('test-session');
+      expect(entry).toBeDefined();
+      expect(entry!.exited).toBe(true);
+      expect(entry!.exitCode).toBe(1);
+    });
+  });
+
+  describe('onSessionExit listener', () => {
+    it('fires when a process exits on its own', () => {
+      const listener = vi.fn();
+      onSessionExit(listener);
+
+      spawnSession('test-session', '/bin/sh', ['-c', 'true'], 80, 24, '/tmp');
+      capturedOnExit!(0);
+
+      expect(listener).toHaveBeenCalledWith('test-session', 0);
+      offSessionExit(listener);
+    });
+
+    it('does not fire after being removed with offSessionExit', () => {
+      const listener = vi.fn();
+      onSessionExit(listener);
+      offSessionExit(listener);
+
+      spawnSession('test-session', '/bin/sh', ['-c', 'true'], 80, 24, '/tmp');
+      capturedOnExit!(0);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('fires for multiple listeners', () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      onSessionExit(listener1);
+      onSessionExit(listener2);
+
+      spawnSession('test-session', '/bin/sh', ['-c', 'true'], 80, 24, '/tmp');
+      capturedOnExit!(42);
+
+      expect(listener1).toHaveBeenCalledWith('test-session', 42);
+      expect(listener2).toHaveBeenCalledWith('test-session', 42);
+
+      offSessionExit(listener1);
+      offSessionExit(listener2);
+    });
+  });
+});

--- a/apps/cli/src/pty-registry.ts
+++ b/apps/cli/src/pty-registry.ts
@@ -11,6 +11,20 @@ export interface PtyEntry {
 
 const registry = new Map<string, PtyEntry>();
 
+type SessionExitListener = (name: string, code: number) => void;
+const exitListeners: SessionExitListener[] = [];
+
+/** Register a callback that fires when any session's process exits. */
+export function onSessionExit(cb: SessionExitListener): void {
+  exitListeners.push(cb);
+}
+
+/** Remove a previously registered session-exit callback. */
+export function offSessionExit(cb: SessionExitListener): void {
+  const idx = exitListeners.indexOf(cb);
+  if (idx >= 0) exitListeners.splice(idx, 1);
+}
+
 export function spawnSession(
   name: string,
   cmd: string,
@@ -40,6 +54,9 @@ export function spawnSession(
   pty.onExit((code) => {
     entry.exited = true;
     entry.exitCode = code;
+    for (const listener of exitListeners) {
+      listener(name, code);
+    }
   });
 
   activity.attach(name, pty);
@@ -52,7 +69,8 @@ export function getSession(name: string): PtyEntry | undefined {
 }
 
 export function hasSession(name: string): boolean {
-  return registry.has(name);
+  const entry = registry.get(name);
+  return entry != null && !entry.exited;
 }
 
 export function killSession(name: string): void {


### PR DESCRIPTION
When an agent process exits on its own (crash, Ctrl+D), Kirby now correctly updates the sidebar indicator from running (green ●) to stopped (gray ○).

## Root cause

`hasSession()` only checked if an entry existed in the registry map, not whether the process had exited. And no refresh was triggered when a process self-terminated.

## Fix

- `hasSession()` now returns `false` when `entry.exited` is `true`
- Added `onSessionExit`/`offSessionExit` listener API to pty-registry
- `useSessionManager` subscribes to exit events and calls `refreshSessions()`

## Tests

6 new unit tests in `pty-registry.spec.ts` covering both the `hasSession` fix and the exit listener mechanism. All 282 CLI tests pass.