### PR TITLE
feat(plan): PR-review plan/checkout workflow + capability-aware agent registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,58 @@
 # 😸 Kirby
 
-A terminal UI for managing multiple AI coding sessions across git worktrees, with integrated GitHub and Azure DevOps pull request tracking.
+A terminal UI for running AI coding agents across git worktrees, with pull request status and code review built in.
+
+Kirby started as a way to solve my own workflow. I spend my working hours in a large monorepo, usually with several features and reviews in flight at once, and I wanted one place to manage the worktrees and agent sessions that go with them and to help me automate PR reviews while remaining familiar with the source code. It's early and still moving fast, @minigod and I have been using it as our daily worktree manager and now I feel it is feature complete enough to share with others who might have a similar workflow.
 
 ## Features
 
-- **Session management** — create, kill, and delete worktree-based AI coding sessions from a single TUI
-- **PR tracking** — view open, draft, and merged pull requests alongside your active sessions
-- **Code reviews** — see PRs where you're a reviewer, grouped by status (needs review, waiting for author, approved)
-- **Branch sync** — automatic merge detection, conflict counting, auto-delete of merged branches, one-key rebase
-- **Configurable AI tool** — switch between Claude, Codex, Gemini, Copilot, or a custom command
-- **Settings panel** — auto-detect VCS provider, configure sync intervals, and set project preferences
+### Worktree management
 
-## Screenshot
+- **Worktree-based sessions** - every branch gets its own git worktree and a long-lived agent session. Spin them up, switch between them, and tear them down without stashing or disturbing your main checkout. Built for monorepos where several features are in progress at the same time.
+- **PR status next to every worktree** - the sidebar shows each branch's pull request state inline: open, draft, or merged, CI result, review status, and conflict count against the base. Most worktree tools stop at the branch name; Kirby tells you where the branch actually stands.
+- **GitHub and Azure DevOps** - both supported today. Support for other providers can be added via pull request.
+- **Branch sync** - detects merged branches, counts conflicts against the base, auto-deletes merged worktrees, and rebases onto the base with one key.
 
-The sidebar shows active PR's and lets you create a new agent session and worktree based on the branch.
-<img width="1682" height="1518" alt="image" src="https://github.com/user-attachments/assets/db4b13b2-3b8d-4783-8c58-353cff0243a2" />
+### Review automations - draft reviews and draft plans
 
-## Configuration
+- **Agent-drafted reviews** - point an agent at a pull request and have it review the diff. It leaves inline draft comments that show up right in the diff viewer, and you pick which ones to actually post and which to drop. You stay the author of record; the agent just does the first pass.
+- **Plan comments into a cart** - the other direction: on a PR you're resolving, select the review comments you want to address, optionally annotate each with a note on how you want it handled, and add them to a draft plan like you're shopping on eBay. Then when you are happy you can go to checkout and send the plan to a new session and the agent gets to work.
+- **Review in the terminal** - browse a PR's files and diffs, read comment threads, reply, and resolve or reopen threads without leaving the TUI.
 
-Press `s` to open the settings panel. From there you can configure the VCS provider, AI tool, sync intervals, and auto-behaviors (auto-delete merged branches, auto-rebase). Press `a` to auto-detect project settings from the git remote.
+### Customizable and Agent agnostic
+
+- **Pick your agent** - Claude, Codex, Gemini, Copilot, or OpenCode, configurable per project.
+- **Customizable keybindings** - Normie and Vim presets out of the box, remappable from the Controls panel.
+
+> Kirby is early-stage software. It works well enough that we rely on it every day, but expect rough edges and breaking changes.
 
 ## Prerequisites
 
-- Node.js 20+
 - git
-- `gh` CLI (for GitHub provider)
+- For GitHub: the `gh` CLI, authenticated
+- For Azure DevOps: a personal access token with repo and pull request access
 
 ## Installation
 
-### Global install (recommended)
+### Global install (no NPM package yet)
 
 Build a self-contained bundle and install the `kirby` command globally:
 
 ```sh
-npm install
+npm ci
 npx nx install-global cli
 ```
 
-Then run from any project directory:
+Then run `kirby` from any project directory.
 
-```sh
-kirby
-kirby /path/to/project
-```
+## Configuration
 
-### Development
+On first run in a new project, an onboarding wizard walks you through connecting your VCS provider. After that, press the settings key (`s` by default) to change the provider, AI agent, sync intervals, and auto-behaviors (auto-delete merged branches, auto-rebase). Auto-detect fills in project settings from the git remote.
 
-```sh
-npm install
-npx nx serve cli
-```
+Keybindings are remappable. Kirby ships with a Normie preset and a Vim preset; open the Controls panel to switch presets or rebind individual actions.
 
-## Testing
+## Screenshot
 
-### Unit & Component Tests
+The sidebar lists your branches with their PR status and lets you start an agent session and worktree from any of them.
 
-```sh
-npx nx test worktree-manager   # library unit tests
-npx nx test cli                # CLI unit + integration tests (vitest)
-```
-
-### E2E Tests
-
-E2E tests drive Kirby in headless Chromium via `@playwright/test` and the `apps/cli-wterm-host/` bridge (which runs Kirby in a PTY and streams it over WebSocket to `@wterm/dom`).
-
-```sh
-npx nx e2e cli-e2e
-```
-
-This runs fast startup/navigation tests. Integration tests that hit GitHub are **skipped** unless `GH_TOKEN` is set.
-
-### Integration Tests
-
-Integration tests exercise real GitHub operations — creating branches, PRs, merging, and verifying auto-delete behavior.
-
-```sh
-GH_TOKEN=<fine-grained-PAT> npx nx e2e:integration cli-e2e
-```
-
-The PAT needs **Contents: R/W** and **Pull requests: R/W** scoped to the test repo. By default the tests use `kirby-test-runner/kirby-integration-test-repository` — override with `TEST_REPO=owner/repo`.
-
-In CI, integration tests run in a separate **Integration Tests** workflow (`.github/workflows/integration.yml`) using the `INTEGRATION_TEST_PAT` repo secret.
-
-## License
-
-MIT
+<img alt="image" src="https://github.com/user-attachments/assets/db4b13b2-3b8d-4783-8c58-353cff0243a2" />

--- a/apps/cli-e2e/src/plan-checkout.test.ts
+++ b/apps/cli-e2e/src/plan-checkout.test.ts
@@ -1,0 +1,158 @@
+import { execSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from './fixtures/kirby.js';
+import { registerCleanup } from './setup/git-repo.js';
+import { sidebarLocator } from './setup/sidebar.js';
+import { TEST_REPO } from './setup/constants.js';
+
+// Exercises the "add comments to a plan" (add-to-cart) feature against
+// fixture PR #38 (undo feature), which has inline review comments on
+// src/undo.c. Stops at the checkout pane — pressing "send" would spawn a
+// real `claude`, which isn't available in CI. The unit specs cover the
+// send/orchestration paths (checkout-orchestrator.spec.ts).
+
+const hasGhToken = !!process.env.GH_TOKEN;
+
+const cloneDir = mkdtempSync(join(tmpdir(), 'kirby-plan-clone-'));
+registerCleanup(cloneDir);
+
+if (hasGhToken) {
+  const token = process.env.GH_TOKEN;
+  execSync(`gh repo clone "${TEST_REPO}" "${cloneDir}"`, { stdio: 'pipe' });
+  execSync(
+    `git remote set-url origin "https://x-access-token:${token}@github.com/${TEST_REPO}.git"`,
+    { cwd: cloneDir, stdio: 'pipe' }
+  );
+  execSync('git config user.email "e2e@kirby.dev"', {
+    cwd: cloneDir,
+    stdio: 'pipe',
+  });
+  execSync('git config user.name "Kirby E2E"', { cwd: cloneDir, stdio: 'pipe' });
+  execSync('git fetch origin fixture/add-undo-feature', {
+    cwd: cloneDir,
+    stdio: 'pipe',
+  });
+}
+
+test.describe('@integration Plan Checkout', () => {
+  test.skip(!hasGhToken, 'Requires GH_TOKEN for real GitHub ops');
+
+  test.use({
+    kirbyRepoPath: cloneDir,
+    kirbyConfig: { keybindPreset: 'vim' },
+    rows: 60,
+    cols: 120,
+  });
+
+  async function pressUntilSelected(
+    kirby: { term: { press: (k: string) => Promise<void> } },
+    selectedLocator: Locator,
+    maxPresses: number
+  ): Promise<boolean> {
+    for (let i = 0; i <= maxPresses; i++) {
+      try {
+        await selectedLocator.waitFor({ state: 'visible', timeout: 1_500 });
+        return true;
+      } catch {
+        if (i === maxPresses) return false;
+        await kirby.term.press('j');
+      }
+    }
+    return false;
+  }
+
+  async function openPr38DiffAndSelectThread(kirby: {
+    term: {
+      page: Page;
+      press: (k: string) => Promise<void>;
+      getByText: Page['getByText'];
+    };
+  }) {
+    await expect(kirby.term.getByText('Kirby').first()).toBeVisible();
+    await expect(
+      kirby.term.getByText('Add undo feature with history stack').first()
+    ).toBeVisible({ timeout: 30_000 });
+
+    const pr38 = sidebarLocator(kirby.term.page, 'Add undo feature');
+    const landed = await pressUntilSelected(
+      { term: kirby.term },
+      pr38.selected().first(),
+      20
+    );
+    if (!landed) throw new Error('Could not select PR #38');
+
+    await kirby.term.press('d');
+    await kirby.term.page
+      .locator('.term-row', { hasText: /undo\.c/ })
+      .first()
+      .waitFor({ state: 'visible', timeout: 30_000 });
+
+    const undoSelected = kirby.term.page
+      .locator('.term-row', { hasText: /›.*undo\.c/ })
+      .first();
+    const gotUndo = await pressUntilSelected(
+      { term: kirby.term },
+      undoSelected,
+      10
+    );
+    if (!gotUndo) throw new Error('Could not select src/undo.c');
+
+    await kirby.term.press('Enter');
+    await expect(kirby.term.getByText(/Magic number/).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Select the first remote thread (vim: c = next-comment). The
+    // [r]eply hint confirms the selection committed.
+    await kirby.term.press('c');
+    await expect(kirby.term.getByText(/\[r\]eply/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  test('add a comment to the plan, annotate it, and open checkout', async ({
+    kirby,
+  }) => {
+    await openPr38DiffAndSelectThread({ term: kirby.term });
+
+    // `a` adds the selected thread to the plan — the top-right indicator
+    // shows "Plan (1)".
+    await kirby.term.press('a');
+    await expect(kirby.term.getByText(/Plan \(1\)/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // `o` (vim checkout) opens the interactive checklist pane.
+    await kirby.term.press('o');
+    await expect(
+      kirby.term.getByText(/Plan Checkout \(1\)/).first()
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(kirby.term.getByText(/undo\.c:/).first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Esc returns to the diff, plan intact.
+    await kirby.term.press('Escape');
+    await expect(kirby.term.getByText(/Plan \(1\)/).first()).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test('toggling a comment off removes it from the plan', async ({ kirby }) => {
+    await openPr38DiffAndSelectThread({ term: kirby.term });
+
+    await kirby.term.press('a');
+    await expect(kirby.term.getByText(/Plan \(1\)/).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Second `a` toggles it back off — the indicator disappears.
+    await kirby.term.press('a');
+    await expect(kirby.term.getByText(/Plan \(1\)/)).not.toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/apps/cli-e2e/src/terminal-input.test.ts
+++ b/apps/cli-e2e/src/terminal-input.test.ts
@@ -1,14 +1,15 @@
 import { test, expect } from './fixtures/kirby.js';
 
 // Vim preset for the keybindings this test uses (s settings, c branch
-// picker, K kill, x delete). We deliberately do NOT pre-set aiCommand —
-// the test configures it through the settings UI.
+// picker, K kill, x delete). `aiCommand: 'bash'` is an unrecognized
+// command, so it resolves to the hidden test-runner agent and spawns a
+// real bash we can drive to verify terminal I/O forwarding.
 test.use({
-  kirbyConfig: { keybindPreset: 'vim' },
+  kirbyConfig: { keybindPreset: 'vim', aiCommand: 'bash' },
 });
 
 test.describe('Terminal Input', () => {
-  test('configure agent via settings, run command, escape, and clean up', async ({
+  test('run a command in an agent session, escape, and clean up', async ({
     kirby,
   }) => {
     const branchName = 'e2e-raw-input';
@@ -17,31 +18,15 @@ test.describe('Terminal Input', () => {
     await expect(kirby.term.getByText('Kirby').first()).toBeVisible();
     await expect(kirby.term.getByText('(no sessions)')).toBeVisible();
 
-    // ── 2. Open settings → set AI Tool to 'bash' ─────────────────
+    // ── 2. Settings smoke: open and close ────────────────────────
     await kirby.term.type('s');
     await expect(kirby.term.getByText('Settings').first()).toBeVisible();
+    await expect(kirby.term.getByText('AI Tool').first()).toBeVisible();
 
-    // Controls is first field — navigate down to AI Tool.
-    await kirby.term.type('j');
-    await kirby.term.page.waitForTimeout(300);
-    // Enter custom-edit mode for AI Tool.
-    await kirby.term.press('Enter');
-    await kirby.term.page.waitForTimeout(500);
-
-    // Type the custom command.
-    await kirby.term.type('bash');
-    await kirby.term.page.waitForTimeout(500);
-
-    // Save with Enter.
-    await kirby.term.press('Enter');
-
-    // Verify the custom value is displayed.
-    await expect(kirby.term.getByText('Custom: bash').first()).toBeVisible();
-
-    // Close settings — wait for save to settle, then press Esc.
-    // Can't assert on 'Settings' visibility because getByText is
-    // case-insensitive and matches both the panel title and the sidebar
-    // keybind hint ("s settings"). Check for the AI Tool label (panel-only).
+    // Close settings. Can't assert on 'Settings' visibility because
+    // getByText is case-insensitive and matches both the panel title and
+    // the sidebar keybind hint ("s settings"). Check for the AI Tool
+    // label (panel-only).
     await kirby.term.page.waitForTimeout(1_000);
     await kirby.term.press('Escape');
     await expect(kirby.term.getByText('AI Tool').first()).not.toBeVisible({

--- a/apps/cli/src/agents/registry.spec.ts
+++ b/apps/cli/src/agents/registry.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import type { AppConfig } from '@kirby/vcs-core';
+import {
+  AGENTS,
+  agentIdFromCommand,
+  makeTestAgent,
+  resolveAgent,
+  isKnownAgentId,
+  SEED_PROMPT_ENV,
+  SEED_SYSTEM_ENV,
+} from './registry.js';
+
+function config(partial: Partial<AppConfig>): AppConfig {
+  return { vendorAuth: {}, vendorProject: {}, ...partial };
+}
+
+describe('agent registry', () => {
+  it('exposes the five user-selectable agents, none hidden', () => {
+    expect(AGENTS.map((a) => a.id)).toEqual([
+      'claude',
+      'codex',
+      'gemini',
+      'copilot',
+      'opencode',
+    ]);
+    expect(AGENTS.every((a) => !a.hidden)).toBe(true);
+  });
+
+  describe('agentIdFromCommand', () => {
+    it('defaults to claude when empty', () => {
+      expect(agentIdFromCommand(undefined)).toBe('claude');
+      expect(agentIdFromCommand('')).toBe('claude');
+    });
+
+    it('maps legacy preset strings back to their agent', () => {
+      expect(agentIdFromCommand('claude --continue || claude')).toBe('claude');
+      expect(agentIdFromCommand('codex')).toBe('codex');
+      expect(agentIdFromCommand('gemini')).toBe('gemini');
+      expect(agentIdFromCommand('copilot')).toBe('copilot');
+      expect(agentIdFromCommand('gh copilot')).toBe('copilot');
+      expect(agentIdFromCommand('opencode')).toBe('opencode');
+    });
+
+    it('routes unrecognized commands to the hidden test runner', () => {
+      expect(agentIdFromCommand('cat')).toBe('test');
+      expect(agentIdFromCommand('echo hi && sleep 300')).toBe('test');
+      expect(agentIdFromCommand('node /tmp/fake-agent.mjs')).toBe('test');
+    });
+  });
+
+  describe('resolveAgent', () => {
+    it('prefers explicit agentId over aiCommand', () => {
+      const agent = resolveAgent(
+        config({ agentId: 'codex', aiCommand: 'cat' })
+      );
+      expect(agent.id).toBe('codex');
+    });
+
+    it('migrates legacy aiCommand when agentId is unset', () => {
+      expect(resolveAgent(config({ aiCommand: 'gemini' })).id).toBe('gemini');
+    });
+
+    it('routes an unrecognized aiCommand to the test runner that runs it raw', () => {
+      const agent = resolveAgent(config({ aiCommand: 'cat' }));
+      expect(agent.id).toBe('test');
+      expect(agent.hidden).toBe(true);
+      expect(agent.blank()).toEqual({ cmd: '/bin/sh', args: ['-c', 'cat'] });
+    });
+
+    it('defaults to claude with an empty config', () => {
+      expect(resolveAgent(config({})).id).toBe('claude');
+    });
+  });
+
+  describe('launch specs', () => {
+    const claude = AGENTS.find((a) => a.id === 'claude')!;
+    const copilot = AGENTS.find((a) => a.id === 'copilot')!;
+    const codex = AGENTS.find((a) => a.id === 'codex')!;
+    const gemini = AGENTS.find((a) => a.id === 'gemini')!;
+    const opencode = AGENTS.find((a) => a.id === 'opencode')!;
+
+    it('claude blank / seed pass the prompt as one argv element', () => {
+      expect(claude.blank()).toEqual({ cmd: 'claude', args: [] });
+      expect(claude.seed!('weird \'quotes\' and "dquotes"')).toEqual({
+        cmd: 'claude',
+        args: ['weird \'quotes\' and "dquotes"'],
+      });
+    });
+
+    it('claude seed uses --append-system-prompt when guidance is given', () => {
+      expect(
+        claude.seed!('do the thing', { appendSystemPrompt: 'be nice' })
+      ).toEqual({
+        cmd: 'claude',
+        args: ['--append-system-prompt', 'be nice', 'do the thing'],
+      });
+    });
+
+    it('claude continue-or-seed delivers the prompt via env, not the command string', () => {
+      const spec = claude.continueOrSeed!('the plan');
+      expect(spec.cmd).toBe('/bin/sh');
+      expect(spec.args[0]).toBe('-c');
+      expect(spec.args[1]).toBe(
+        `claude --continue || claude "$${SEED_PROMPT_ENV}"`
+      );
+      expect(spec.args[1]).not.toContain('the plan');
+      expect(spec.env).toEqual({ [SEED_PROMPT_ENV]: 'the plan' });
+    });
+
+    it('claude continue-or-seed threads the system prompt via env too', () => {
+      const spec = claude.continueOrSeed!('the plan', {
+        appendSystemPrompt: 'guidance',
+      });
+      expect(spec.args[1]).toBe(
+        `claude --continue || claude --append-system-prompt "$${SEED_SYSTEM_ENV}" "$${SEED_PROMPT_ENV}"`
+      );
+      expect(spec.env).toEqual({
+        [SEED_PROMPT_ENV]: 'the plan',
+        [SEED_SYSTEM_ENV]: 'guidance',
+      });
+    });
+
+    it('copilot seeds with -i and has no continue', () => {
+      expect(copilot.seed!('hi')).toEqual({
+        cmd: 'copilot',
+        args: ['-i', 'hi'],
+      });
+      expect(copilot.continueOrBlank).toBeUndefined();
+      expect(copilot.continueOrSeed).toBeUndefined();
+    });
+
+    it('codex/gemini/opencode seed with their respective flags', () => {
+      expect(codex.seed!('p')).toEqual({ cmd: 'codex', args: ['p'] });
+      expect(gemini.seed!('p')).toEqual({ cmd: 'gemini', args: ['-i', 'p'] });
+      expect(opencode.seed!('p')).toEqual({
+        cmd: 'opencode',
+        args: ['--prompt', 'p'],
+      });
+    });
+
+    it('only claude advertises append-system-prompt support', () => {
+      expect(claude.supportsAppendSystemPrompt).toBe(true);
+      for (const a of [copilot, codex, gemini, opencode]) {
+        expect(a.supportsAppendSystemPrompt).toBe(false);
+      }
+    });
+  });
+
+  describe('makeTestAgent', () => {
+    it('runs the raw command and exposes the seed prompt via env', () => {
+      const agent = makeTestAgent('cat');
+      expect(agent.blank()).toEqual({ cmd: '/bin/sh', args: ['-c', 'cat'] });
+      expect(agent.seed!('hello')).toEqual({
+        cmd: '/bin/sh',
+        args: ['-c', 'cat'],
+        env: { [SEED_PROMPT_ENV]: 'hello' },
+      });
+    });
+  });
+
+  describe('isKnownAgentId', () => {
+    it('recognizes the public ids but not the hidden test runner', () => {
+      expect(isKnownAgentId('claude')).toBe(true);
+      expect(isKnownAgentId('opencode')).toBe(true);
+      expect(isKnownAgentId('test')).toBe(false);
+      expect(isKnownAgentId('nonsense')).toBe(false);
+    });
+  });
+});

--- a/apps/cli/src/agents/registry.ts
+++ b/apps/cli/src/agents/registry.ts
@@ -1,0 +1,229 @@
+import type { AgentId, AppConfig } from '@kirby/vcs-core';
+
+// ── Agent capability registry ────────────────────────────────────
+//
+// A single, capability-aware description of every AI agent Kirby can
+// drive. Each definition knows how to build the argv for the ways we
+// launch it — blank, seed-with-a-prompt, or continue-a-prior-session —
+// so callers never hand-compose shell strings (which is how prompt
+// quote-stripping and the hardcoded-`claude` review bug crept in).
+//
+// Prompts are always passed as a single argv element (or via an env
+// var for the shell-composed `continue || …` paths), never interpolated
+// into a command string. That removes both the quoting corruption and
+// the shell-injection surface.
+//
+// Capability notes (verified against each CLI's docs, erring cautious):
+//   • Only Claude supports appending a system prompt (`--append-system-prompt`).
+//     For every other agent, guidance is folded into the user prompt by the
+//     launcher instead.
+//   • `continue` is Claude-only for now. Copilot's `--continue` resumes the
+//     most-recently-closed session GLOBALLY (not scoped to the folder/worktree),
+//     so it is unsafe for us; OpenCode's scoping is undocumented. Codex and
+//     Gemini have worktree-safe resume we may adopt later, but we keep the
+//     first cut simple and cautious: non-Claude agents decline continue and
+//     the launcher degrades to blank/seed.
+
+/** Extends the public {@link AgentId} with the internal, UI-hidden test runner. */
+export type ResolvedAgentId = AgentId | 'test';
+
+export interface LaunchSpec {
+  cmd: string;
+  args: string[];
+  /**
+   * Extra environment variables. Merged over `process.env` by
+   * `spawnSession` (never replaces it). Used to deliver a seed prompt to
+   * the shell-composed `continue || seed` path without ever placing the
+   * prompt text in the command string.
+   */
+  env?: Record<string, string | undefined>;
+}
+
+export interface SeedOptions {
+  /**
+   * Guidance to install as a system prompt. Honored natively only by
+   * agents with {@link AgentDefinition.supportsAppendSystemPrompt}; for
+   * the rest the launcher folds it into the prompt before calling
+   * `seed`, so implementations that don't support it can ignore this.
+   */
+  appendSystemPrompt?: string;
+}
+
+export interface AgentDefinition {
+  id: ResolvedAgentId;
+  /** Display name shown in settings. */
+  name: string;
+  /** Excluded from the settings picker (`AI_PRESETS`). The test runner. */
+  hidden?: boolean;
+  /** Whether the CLI can take a system prompt natively (Claude only). */
+  supportsAppendSystemPrompt: boolean;
+  /** Start a blank interactive session. */
+  blank(): LaunchSpec;
+  /**
+   * Start a fresh interactive session pre-seeded with a prompt.
+   * `undefined` ⇒ the agent cannot seed an interactive session; the
+   * launcher falls back to {@link blank}.
+   */
+  seed?(prompt: string, opts?: SeedOptions): LaunchSpec;
+  /**
+   * Resume a prior conversation in the CWD, falling back to a blank
+   * session. `undefined` ⇒ no worktree-safe continue; launcher uses
+   * {@link blank}.
+   */
+  continueOrBlank?(): LaunchSpec;
+  /**
+   * Resume a prior conversation in the CWD, falling back to seeding a
+   * fresh one with the prompt. `undefined` ⇒ launcher uses {@link seed}.
+   */
+  continueOrSeed?(prompt: string, opts?: SeedOptions): LaunchSpec;
+}
+
+// Env var names for the shell-composed `continue || seed` path.
+export const SEED_PROMPT_ENV = 'KIRBY_SEED_PROMPT';
+export const SEED_SYSTEM_ENV = 'KIRBY_SEED_SYSTEM';
+
+const CLAUDE: AgentDefinition = {
+  id: 'claude',
+  name: 'Claude',
+  supportsAppendSystemPrompt: true,
+  blank: () => ({ cmd: 'claude', args: [] }),
+  seed: (prompt, opts) =>
+    opts?.appendSystemPrompt
+      ? {
+          cmd: 'claude',
+          args: ['--append-system-prompt', opts.appendSystemPrompt, prompt],
+        }
+      : { cmd: 'claude', args: [prompt] },
+  continueOrBlank: () => ({
+    cmd: '/bin/sh',
+    args: ['-c', 'claude --continue || claude'],
+  }),
+  continueOrSeed: (prompt, opts) => {
+    const sys = opts?.appendSystemPrompt;
+    const fresh = sys
+      ? `claude --append-system-prompt "$${SEED_SYSTEM_ENV}" "$${SEED_PROMPT_ENV}"`
+      : `claude "$${SEED_PROMPT_ENV}"`;
+    return {
+      cmd: '/bin/sh',
+      args: ['-c', `claude --continue || ${fresh}`],
+      env: {
+        [SEED_PROMPT_ENV]: prompt,
+        ...(sys ? { [SEED_SYSTEM_ENV]: sys } : {}),
+      },
+    };
+  },
+};
+
+const COPILOT: AgentDefinition = {
+  id: 'copilot',
+  name: 'Copilot',
+  supportsAppendSystemPrompt: false,
+  blank: () => ({ cmd: 'copilot', args: [] }),
+  // `-i` starts an interactive session seeded with the prompt (verified
+  // empirically). `-p` is the one-shot programmatic mode that exits, so
+  // we deliberately don't use it for a live pane.
+  seed: (prompt) => ({ cmd: 'copilot', args: ['-i', prompt] }),
+  // `copilot --continue` resumes the most-recently-closed session
+  // globally, not the one for this worktree — unsafe, so no continue.
+};
+
+const CODEX: AgentDefinition = {
+  id: 'codex',
+  name: 'Codex',
+  supportsAppendSystemPrompt: false,
+  blank: () => ({ cmd: 'codex', args: [] }),
+  seed: (prompt) => ({ cmd: 'codex', args: [prompt] }),
+};
+
+const GEMINI: AgentDefinition = {
+  id: 'gemini',
+  name: 'Gemini',
+  supportsAppendSystemPrompt: false,
+  blank: () => ({ cmd: 'gemini', args: [] }),
+  // `-i`/`--prompt-interactive` seeds an interactive session; `-p` is
+  // the headless mode that exits.
+  seed: (prompt) => ({ cmd: 'gemini', args: ['-i', prompt] }),
+};
+
+const OPENCODE: AgentDefinition = {
+  id: 'opencode',
+  name: 'OpenCode',
+  supportsAppendSystemPrompt: false,
+  blank: () => ({ cmd: 'opencode', args: [] }),
+  seed: (prompt) => ({ cmd: 'opencode', args: ['--prompt', prompt] }),
+  // `--continue`/`-c` scope is undocumented — treat as unsafe for now.
+};
+
+/** The user-selectable agents, in settings-display order. */
+export const AGENTS: readonly AgentDefinition[] = [
+  CLAUDE,
+  CODEX,
+  GEMINI,
+  COPILOT,
+  OPENCODE,
+];
+
+/**
+ * The hidden test-runner agent. Runs an arbitrary command through
+ * `sh -c` so the e2e harness can drive Kirby with fake agents (`cat`,
+ * `sleep 300`, the fake-agent script, …). Not shown in settings; only
+ * reachable when the resolved id is `test`.
+ */
+export function makeTestAgent(rawCommand: string): AgentDefinition {
+  return {
+    id: 'test',
+    name: 'Test Runner',
+    hidden: true,
+    supportsAppendSystemPrompt: false,
+    blank: () => ({ cmd: '/bin/sh', args: ['-c', rawCommand] }),
+    // Seeding a fake is best-effort: run the raw command and expose the
+    // prompt via env for fakes that choose to read it.
+    seed: (prompt) => ({
+      cmd: '/bin/sh',
+      args: ['-c', rawCommand],
+      env: { [SEED_PROMPT_ENV]: prompt },
+    }),
+  };
+}
+
+const KNOWN_IDS = new Set<string>(AGENTS.map((a) => a.id));
+
+/**
+ * Map a legacy `aiCommand` string back to an agent id. Recognized
+ * preset commands map to their agent; anything else (custom wrappers,
+ * the e2e fakes) routes to the hidden test runner so it runs verbatim.
+ */
+export function agentIdFromCommand(
+  aiCommand: string | undefined
+): ResolvedAgentId {
+  if (!aiCommand) return 'claude';
+  const cmd = aiCommand.trim();
+  if (cmd.startsWith('claude')) return 'claude';
+  if (cmd.startsWith('codex')) return 'codex';
+  if (cmd.startsWith('gemini')) return 'gemini';
+  if (
+    cmd === 'copilot' ||
+    cmd.startsWith('copilot ') ||
+    cmd.startsWith('gh copilot')
+  )
+    return 'copilot';
+  if (cmd.startsWith('opencode')) return 'opencode';
+  return 'test';
+}
+
+/**
+ * Resolve the agent to launch for a config. Prefers the explicit
+ * `agentId`; otherwise migrates the legacy `aiCommand`. Unknown ids and
+ * the `test` id resolve to the hidden test runner bound to `aiCommand`.
+ */
+export function resolveAgent(config: AppConfig): AgentDefinition {
+  const id: ResolvedAgentId =
+    config.agentId ?? agentIdFromCommand(config.aiCommand);
+  if (id === 'test') return makeTestAgent(config.aiCommand ?? '');
+  const found = AGENTS.find((a) => a.id === id);
+  return found ?? CLAUDE;
+}
+
+export function isKnownAgentId(id: string): id is AgentId {
+  return KNOWN_IDS.has(id);
+}

--- a/apps/cli/src/components/AsyncOpsIndicator.tsx
+++ b/apps/cli/src/components/AsyncOpsIndicator.tsx
@@ -1,7 +1,6 @@
 import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useAsyncOps } from '../context/AsyncOpsContext.js';
-import { useLayout } from '../context/LayoutContext.js';
 import type { OperationName } from '../hooks/useAsyncOperation.js';
 
 // Human-readable labels for each async operation. Falls back to the
@@ -24,30 +23,14 @@ const OP_LABELS: Partial<Record<OperationName, string>> = {
 // Width reservation for the spinner + label. Roughly enough for the
 // longest op name list we expect (e.g. "sync, rebase, fetch-branches").
 const INDICATOR_WIDTH = 40;
-// 2-col gutter from the right edge — matches ToastContainer's EDGE_GUTTER
-// so the spinner lines up visually with the toasts below it.
-const EDGE_GUTTER = 2;
-// Row 1 puts the spinner on the pane's title row (inside the top
-// border). Paints to the right of the title text — no overlap in
-// practice because titles are left-aligned and this is right-aligned.
-const TOP_ROW = 1;
 
-// Absolutely-positioned loading indicator in the top-right corner.
-// Shown while any async operations are in flight (`asyncOps.inFlight`
-// is non-empty). The label next to the spinner says what's loading
-// (comma-separated op names).
-//
-// Renders `null` when idle — zero visual weight.
-//
-// Positioning strategy mirrors ToastContainer: full-screen
-// `position="absolute"` wrapper with explicit width/height from
-// LayoutContext, then flex-align inside to push the indicator to the
-// top-right. The inner stack is a column so future additions (e.g. a
-// second indicator row) would stack below the spinner naturally.
-export function AsyncOpsIndicator() {
+// Margin-free async-ops content: the label + spinner row, or null when
+// idle. Positioning is owned by TopRightOverlay, which stacks this above
+// the plan indicator and toasts in a single top-right column. Shown
+// while any async operations are in flight; the label (comma-separated
+// op names) says what's loading.
+export function AsyncOpsContent() {
   const asyncOps = useAsyncOps();
-  const { termCols, termRows } = useLayout();
-
   if (asyncOps.inFlight.size === 0) return null;
 
   const label = [...asyncOps.inFlight]
@@ -55,31 +38,9 @@ export function AsyncOpsIndicator() {
     .join(', ');
 
   return (
-    <Box
-      position="absolute"
-      // Same as Modal / ToastContainer — Ink types lag the runtime for
-      // offsets. Greppable cast.
-      {...({ top: 0, left: 0 } as object)}
-      width={termCols}
-      height={termRows}
-      alignItems="flex-start"
-      justifyContent="flex-end"
-    >
-      <Box
-        marginTop={TOP_ROW}
-        marginRight={EDGE_GUTTER}
-        width={INDICATOR_WIDTH}
-        // Row flex: main-axis is horizontal, so justifyContent pushes
-        // the label+spinner pair to the right edge of the 40-col
-        // reserved column. Inside the row, label renders first and
-        // the spinner second — so the animated character sits on the
-        // RIGHT of the text.
-        justifyContent="flex-end"
-        gap={1}
-      >
-        <Text>{label}</Text>
-        <Spinner />
-      </Box>
+    <Box width={INDICATOR_WIDTH} justifyContent="flex-end" gap={1}>
+      <Text>{label}</Text>
+      <Spinner />
     </Box>
   );
 }

--- a/apps/cli/src/components/CommentThread.spec.tsx
+++ b/apps/cli/src/components/CommentThread.spec.tsx
@@ -100,6 +100,47 @@ describe('CommentThreadCard — header overflow', () => {
   });
 });
 
+describe('in-plan badge', () => {
+  it('shows the ◉ badge on a remote card when in plan (no note)', () => {
+    const { lastFrame } = render(
+      <CommentThreadCard thread={makeThread()} inPlan maxWidth={80} />
+    );
+    const visible = stripAnsi(lastFrame() ?? '');
+    expect(visible).toContain('◉ plan');
+    expect(visible).not.toContain('✎');
+  });
+
+  it('shows the ✎ badge when the plan item is annotated', () => {
+    const { lastFrame } = render(
+      <CommentThreadCard thread={makeThread()} inPlan hasAnnotation maxWidth={80} />
+    );
+    expect(stripAnsi(lastFrame() ?? '')).toContain('✎ plan');
+  });
+
+  it('shows no badge when not in plan', () => {
+    const { lastFrame } = render(
+      <CommentThreadCard thread={makeThread()} maxWidth={80} />
+    );
+    expect(stripAnsi(lastFrame() ?? '')).not.toContain('plan');
+  });
+
+  it('renders the badge on a local card too', () => {
+    const { lastFrame } = render(
+      <LocalCommentCard comment={makeReview()} inPlan maxWidth={80} />
+    );
+    expect(stripAnsi(lastFrame() ?? '')).toContain('◉ plan');
+  });
+
+  it('keeps the badge on the header row (single line)', () => {
+    const { lastFrame } = render(
+      <CommentThreadCard thread={makeThread()} selected inPlan maxWidth={80} />
+    );
+    const rows = stripAnsi(lastFrame() ?? '').split('\n');
+    const headerRow = rows.find((r) => r.includes('plan'))!;
+    expect(headerRow).toContain('alice');
+  });
+});
+
 describe('LocalCommentCard — header overflow', () => {
   it('renders the header on a single row when selected with full hints', () => {
     const comment = makeReview({

--- a/apps/cli/src/components/CommentThread.tsx
+++ b/apps/cli/src/components/CommentThread.tsx
@@ -46,6 +46,17 @@ interface CommentThreadCardProps {
    * card starts where the code content does. Default 0.
    */
   indent?: number;
+  /** Show the "in plan" badge (comment is queued in the PR plan). */
+  inPlan?: boolean;
+  /** Whether the queued plan item carries a note (badge uses ✎). */
+  hasAnnotation?: boolean;
+}
+
+/** Single-line "in plan" badge shared by both card kinds. */
+function PlanBadge({ hasAnnotation }: { hasAnnotation?: boolean }) {
+  return (
+    <Text color="green">{hasAnnotation ? '  ✎ plan' : '  ◉ plan'}</Text>
+  );
 }
 
 // Constants that mirror the previous ANSI renderer's visual language —
@@ -60,6 +71,8 @@ export const CommentThreadCard = memo(function CommentThreadCard({
   replyBuffer,
   maxWidth,
   indent,
+  inPlan = false,
+  hasAnnotation = false,
 }: CommentThreadCardProps) {
   const rootComment = thread.comments[0];
   if (!rootComment) return null;
@@ -94,6 +107,7 @@ export const CommentThreadCard = memo(function CommentThreadCard({
         <Text dimColor>{` · ${relativeTime(rootComment.createdAt)}`}</Text>
         {thread.isResolved && <Text color="green">{' ✓ resolved'}</Text>}
         {thread.isOutdated && <Text dimColor>{' (outdated)'}</Text>}
+        {inPlan && <PlanBadge hasAnnotation={hasAnnotation} />}
         {selected && !isReplying && (
           <Text dimColor>
             {'  [r]eply'}
@@ -181,6 +195,10 @@ interface LocalCommentCardProps {
   maxWidth?: number;
   /** See CommentThreadCard.indent. */
   indent?: number;
+  /** Show the "in plan" badge (comment is queued in the PR plan). */
+  inPlan?: boolean;
+  /** Whether the queued plan item carries a note (badge uses ✎). */
+  hasAnnotation?: boolean;
 }
 
 export const LocalCommentCard = memo(function LocalCommentCard({
@@ -191,6 +209,8 @@ export const LocalCommentCard = memo(function LocalCommentCard({
   editBuffer,
   maxWidth,
   indent,
+  inPlan = false,
+  hasAnnotation = false,
 }: LocalCommentCardProps) {
   const severityColor = SEVERITY_COLOR[comment.severity] ?? 'gray';
   const statusMark = STATUS_MARK[comment.status];
@@ -220,6 +240,7 @@ export const LocalCommentCard = memo(function LocalCommentCard({
           <Text color={statusMark.color}>{` ${statusMark.char}`}</Text>
         )}
         {pendingDelete && <Text color="red">{'  Delete? [y]es [n]o'}</Text>}
+        {inPlan && <PlanBadge hasAnnotation={hasAnnotation} />}
         {selected && !editing && !pendingDelete && (
           <Text dimColor>{'  [e]dit [x]delete [p]ost'}</Text>
         )}

--- a/apps/cli/src/components/PlanIndicator.spec.tsx
+++ b/apps/cli/src/components/PlanIndicator.spec.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import stripAnsi from 'strip-ansi';
+import { PlanIndicatorContent } from './PlanIndicator.js';
+import type { RemotePlanItem } from '../plan/plan-types.js';
+
+function remote(id: string, annotation?: string): RemotePlanItem {
+  return {
+    kind: 'remote',
+    id,
+    file: `src/${id}.ts`,
+    line: 1,
+    body: `body ${id}`,
+    author: 'a',
+    replies: [],
+    ...(annotation ? { annotation } : {}),
+  };
+}
+
+describe('PlanIndicatorContent', () => {
+  it('shows the count and item lines', () => {
+    const out = stripAnsi(
+      render(<PlanIndicatorContent items={[remote('a'), remote('b')]} />)
+        .lastFrame() ?? ''
+    );
+    expect(out).toContain('Plan (2)');
+    expect(out).toContain('a.ts');
+    expect(out).toContain('b.ts');
+  });
+
+  it('marks annotated items with ✎ and plain items with •', () => {
+    const out = stripAnsi(
+      render(
+        <PlanIndicatorContent items={[remote('a', 'my note'), remote('b')]} />
+      ).lastFrame() ?? ''
+    );
+    expect(out).toContain('✎');
+    expect(out).toContain('•');
+  });
+
+  it('caps at 5 rows with a +N more line', () => {
+    const out = stripAnsi(
+      render(
+        <PlanIndicatorContent
+          items={Array.from({ length: 8 }, (_, i) => remote(`x${i}`))}
+        />
+      ).lastFrame() ?? ''
+    );
+    expect(out).toContain('Plan (8)');
+    expect(out).toContain('+3 more');
+  });
+});

--- a/apps/cli/src/components/PlanIndicator.tsx
+++ b/apps/cli/src/components/PlanIndicator.tsx
@@ -1,21 +1,17 @@
 import { Box, Text } from 'ink';
 import { usePlan } from '../context/PlanContext.js';
 import { useSidebar } from '../context/SidebarContext.js';
-import { useLayout } from '../context/LayoutContext.js';
 import { truncate } from '../utils/truncate.js';
 import type { PlanItem } from '../plan/plan-types.js';
 
 // Top-right "add-to-cart" indicator: a titled box listing the comments
-// queued in the current PR's plan. A sibling of AsyncOpsIndicator (see
-// main.tsx), it shares the same 40-col right column but sits a few rows
-// down so it clears the async spinner (row 1) and the first toast rows.
+// queued in the current PR's plan. Positioned by TopRightOverlay, which
+// stacks it below the async-ops row and above the toasts in a shared
+// 40-col right column.
 //
 // Renders `null` when the plan is empty — zero visual weight otherwise.
 
 const INDICATOR_WIDTH = 40;
-const EDGE_GUTTER = 2;
-// Clear the async spinner (row 1) and a toast or two below it.
-const TOP_OFFSET = 4;
 // Cap the visible rows so a long plan can't overrun the pane; the rest
 // collapse into a "+N more" line.
 const MAX_ROWS = 5;
@@ -40,8 +36,6 @@ export function PlanIndicatorContent({ items }: { items: PlanItem[] }) {
 
   return (
     <Box
-      marginTop={TOP_OFFSET}
-      marginRight={EDGE_GUTTER}
       width={INDICATOR_WIDTH}
       flexDirection="column"
       borderStyle="round"
@@ -66,26 +60,14 @@ export function PlanIndicatorContent({ items }: { items: PlanItem[] }) {
   );
 }
 
-export function PlanIndicator() {
+// Context-reading section for TopRightOverlay: renders the plan box for
+// the currently-selected PR, or null when the plan is empty.
+export function PlanIndicatorSection() {
   const plan = usePlan();
   const { selectedPr } = useSidebar();
-  const { termCols, termRows } = useLayout();
 
   const items = selectedPr ? plan.list(selectedPr.id) : [];
   if (items.length === 0) return null;
 
-  return (
-    <Box
-      position="absolute"
-      // Ink types lag the runtime for offsets — greppable cast, same as
-      // AsyncOpsIndicator / ToastContainer.
-      {...({ top: 0, left: 0 } as object)}
-      width={termCols}
-      height={termRows}
-      alignItems="flex-start"
-      justifyContent="flex-end"
-    >
-      <PlanIndicatorContent items={items} />
-    </Box>
-  );
+  return <PlanIndicatorContent items={items} />;
 }

--- a/apps/cli/src/components/PlanIndicator.tsx
+++ b/apps/cli/src/components/PlanIndicator.tsx
@@ -28,6 +28,44 @@ function locationLabel(item: PlanItem): string {
   return slash >= 0 ? base.slice(slash + 1) : base;
 }
 
+// Pure presentational box — the titled "Plan (N)" list. Split out from
+// the absolute-positioning wrapper so it can be unit-tested without the
+// full-screen overlay (which ink-testing-library can't render in
+// isolation).
+export function PlanIndicatorContent({ items }: { items: PlanItem[] }) {
+  const visible = items.slice(0, MAX_ROWS);
+  const overflow = items.length - visible.length;
+  // Content width inside the bordered box (border 2 + paddingX 2).
+  const contentWidth = INDICATOR_WIDTH - 4;
+
+  return (
+    <Box
+      marginTop={TOP_OFFSET}
+      marginRight={EDGE_GUTTER}
+      width={INDICATOR_WIDTH}
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="green"
+      paddingX={1}
+    >
+      <Text bold color="green">
+        Plan ({items.length})
+      </Text>
+      {visible.map((item) => (
+        <Text key={`${item.kind}:${item.id}`} wrap="truncate-end">
+          {item.annotation ? (
+            <Text color="green">{'✎ '}</Text>
+          ) : (
+            <Text dimColor>{'• '}</Text>
+          )}
+          {truncate(`${locationLabel(item)} ${item.body}`, contentWidth - 2)}
+        </Text>
+      ))}
+      {overflow > 0 && <Text dimColor>+{overflow} more</Text>}
+    </Box>
+  );
+}
+
 export function PlanIndicator() {
   const plan = usePlan();
   const { selectedPr } = useSidebar();
@@ -35,11 +73,6 @@ export function PlanIndicator() {
 
   const items = selectedPr ? plan.list(selectedPr.id) : [];
   if (items.length === 0) return null;
-
-  const visible = items.slice(0, MAX_ROWS);
-  const overflow = items.length - visible.length;
-  // Content width inside the bordered box (border 2 + paddingX 2).
-  const contentWidth = INDICATOR_WIDTH - 4;
 
   return (
     <Box
@@ -52,33 +85,7 @@ export function PlanIndicator() {
       alignItems="flex-start"
       justifyContent="flex-end"
     >
-      <Box
-        marginTop={TOP_OFFSET}
-        marginRight={EDGE_GUTTER}
-        width={INDICATOR_WIDTH}
-        flexDirection="column"
-        borderStyle="round"
-        borderColor="green"
-        paddingX={1}
-      >
-        <Text bold color="green">
-          Plan ({items.length})
-        </Text>
-        {visible.map((item) => (
-          <Text key={`${item.kind}:${item.id}`} wrap="truncate-end">
-            {item.annotation ? (
-              <Text color="green">{'✎ '}</Text>
-            ) : (
-              <Text dimColor>{'• '}</Text>
-            )}
-            {truncate(
-              `${locationLabel(item)} ${item.body}`,
-              contentWidth - 2
-            )}
-          </Text>
-        ))}
-        {overflow > 0 && <Text dimColor>+{overflow} more</Text>}
-      </Box>
+      <PlanIndicatorContent items={items} />
     </Box>
   );
 }

--- a/apps/cli/src/components/PlanIndicator.tsx
+++ b/apps/cli/src/components/PlanIndicator.tsx
@@ -1,0 +1,84 @@
+import { Box, Text } from 'ink';
+import { usePlan } from '../context/PlanContext.js';
+import { useSidebar } from '../context/SidebarContext.js';
+import { useLayout } from '../context/LayoutContext.js';
+import { truncate } from '../utils/truncate.js';
+import type { PlanItem } from '../plan/plan-types.js';
+
+// Top-right "add-to-cart" indicator: a titled box listing the comments
+// queued in the current PR's plan. A sibling of AsyncOpsIndicator (see
+// main.tsx), it shares the same 40-col right column but sits a few rows
+// down so it clears the async spinner (row 1) and the first toast rows.
+//
+// Renders `null` when the plan is empty — zero visual weight otherwise.
+
+const INDICATOR_WIDTH = 40;
+const EDGE_GUTTER = 2;
+// Clear the async spinner (row 1) and a toast or two below it.
+const TOP_OFFSET = 4;
+// Cap the visible rows so a long plan can't overrun the pane; the rest
+// collapse into a "+N more" line.
+const MAX_ROWS = 5;
+
+function locationLabel(item: PlanItem): string {
+  const file = item.file ?? 'general';
+  const base = item.line != null ? `${file}:${item.line}` : file;
+  // Show just the basename to keep the line short in the narrow column.
+  const slash = base.lastIndexOf('/');
+  return slash >= 0 ? base.slice(slash + 1) : base;
+}
+
+export function PlanIndicator() {
+  const plan = usePlan();
+  const { selectedPr } = useSidebar();
+  const { termCols, termRows } = useLayout();
+
+  const items = selectedPr ? plan.list(selectedPr.id) : [];
+  if (items.length === 0) return null;
+
+  const visible = items.slice(0, MAX_ROWS);
+  const overflow = items.length - visible.length;
+  // Content width inside the bordered box (border 2 + paddingX 2).
+  const contentWidth = INDICATOR_WIDTH - 4;
+
+  return (
+    <Box
+      position="absolute"
+      // Ink types lag the runtime for offsets — greppable cast, same as
+      // AsyncOpsIndicator / ToastContainer.
+      {...({ top: 0, left: 0 } as object)}
+      width={termCols}
+      height={termRows}
+      alignItems="flex-start"
+      justifyContent="flex-end"
+    >
+      <Box
+        marginTop={TOP_OFFSET}
+        marginRight={EDGE_GUTTER}
+        width={INDICATOR_WIDTH}
+        flexDirection="column"
+        borderStyle="round"
+        borderColor="green"
+        paddingX={1}
+      >
+        <Text bold color="green">
+          Plan ({items.length})
+        </Text>
+        {visible.map((item) => (
+          <Text key={`${item.kind}:${item.id}`} wrap="truncate-end">
+            {item.annotation ? (
+              <Text color="green">{'✎ '}</Text>
+            ) : (
+              <Text dimColor>{'• '}</Text>
+            )}
+            {truncate(
+              `${locationLabel(item)} ${item.body}`,
+              contentWidth - 2
+            )}
+          </Text>
+        ))}
+        {overflow > 0 && <Text dimColor>+{overflow} more</Text>}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/components/SettingsPanel.tsx
+++ b/apps/cli/src/components/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from '../context/ModalContext.js';
 import { useSessionActions } from '../context/SessionContext.js';
 import { handleSettingsInput } from '../input-handlers.js';
+import { AGENTS } from '../agents/registry.js';
 
 export interface SettingsField {
   label: string;
@@ -22,13 +23,12 @@ export interface SettingsField {
   action?: 'open-controls';
 }
 
-export const AI_PRESETS: { name: string; value: string | null }[] = [
-  { name: 'Claude', value: 'claude --continue || claude' },
-  { name: 'Codex', value: 'codex' },
-  { name: 'Gemini', value: 'gemini' },
-  { name: 'Copilot', value: 'copilot' },
-  { name: 'Custom', value: null },
-];
+// One preset per registered agent (the hidden test-runner agent is not
+// in AGENTS, so it never surfaces here). The stored value is the agent
+// id, resolved back to a launch spec by the agent registry.
+export const AI_PRESETS: { name: string; value: string | null }[] = AGENTS.map(
+  (a) => ({ name: a.name, value: a.id })
+);
 
 export const BOOL_PRESETS: { name: string; value: string | null }[] = [
   { name: 'Off', value: 'false' },
@@ -75,7 +75,7 @@ export function buildSettingsFields(
     },
     {
       label: 'AI Tool',
-      key: 'aiCommand',
+      key: 'agentId',
       presets: AI_PRESETS,
       configBag: 'global',
     },

--- a/apps/cli/src/components/ToastContainer.tsx
+++ b/apps/cli/src/components/ToastContainer.tsx
@@ -1,98 +1,34 @@
 import { Box } from 'ink';
 import { Alert } from '@inkjs/ui';
 import { useToastState } from '../context/ToastContext.js';
-import { useLayout } from '../context/LayoutContext.js';
 
-// Width of the toast column — toasts align to one side inside it, so
+// Width of the toast column — toasts align to the right inside it, so
 // long messages fill out the full 40 cols and short ones hug the edge.
 const TOAST_WIDTH = 40;
-// Gutter between the toast stack and the nearest terminal edges.
-const EDGE_GUTTER = 2;
 
-export type ToastPosition =
-  | 'top-right'
-  | 'top-left'
-  | 'bottom-right'
-  | 'bottom-left';
-
-interface ToastContainerProps {
-  position?: ToastPosition;
-}
-
-// Outer wrapper anchors. The wrapper is a row flex (Ink's default
-// flexDirection), so `alignItems` controls VERTICAL placement
-// (cross-axis) and `justifyContent` controls HORIZONTAL placement
-// (main-axis). The inner stack is a column flex — its alignItems
-// switches axes (cross becomes horizontal). Don't confuse the two.
-const ANCHOR: Record<
-  ToastPosition,
-  {
-    alignItems: 'flex-start' | 'flex-end';
-    justifyContent: 'flex-start' | 'flex-end';
-  }
-> = {
-  'top-right': { alignItems: 'flex-start', justifyContent: 'flex-end' },
-  'top-left': { alignItems: 'flex-start', justifyContent: 'flex-start' },
-  'bottom-right': { alignItems: 'flex-end', justifyContent: 'flex-end' },
-  'bottom-left': { alignItems: 'flex-end', justifyContent: 'flex-start' },
-};
-
-// Floating toast stack. Renders nothing when there are no toasts, so
-// it adds zero visual weight in the common case.
-//
-// ── Positioning strategy ───────────────────────────────────────────
-// A full-screen `position="absolute"` wrapper anchored at top-left
-// with explicit `width`/`height` from LayoutContext, then flex-align
-// inside it to push the inner stack into the chosen corner. This is
-// the same pattern Modal uses. We can't use `top`/`right` offsets
-// directly to push an element into a corner — Ink's runtime accepts
-// them but non-zero values don't reliably apply.
-//
-// ── Input layering ─────────────────────────────────────────────────
-// Toasts don't capture input — they're non-interactive. So this
-// component doesn't need to coordinate with any `useInput` hooks.
-// (Modals are different — see Modal.tsx for the input-layering note.)
-export function ToastContainer({
-  position = 'top-right',
-}: ToastContainerProps = {}) {
+// Margin-free toast stack, or null when there are nothing to show.
+// Positioning is owned by TopRightOverlay, which stacks this below the
+// async-ops row and the plan indicator. Toasts are non-interactive, so
+// this doesn't coordinate with any `useInput` hooks.
+export function ToastStack() {
   const { toasts } = useToastState();
-  const { termCols, termRows } = useLayout();
-
   if (toasts.length === 0) return null;
-
-  const anchor = ANCHOR[position];
-  const isTop = position === 'top-right' || position === 'top-left';
-  const isRight = position === 'top-right' || position === 'bottom-right';
 
   return (
     <Box
-      position="absolute"
-      // Ink supports this offset; types lag. Same greppable cast as Modal.
-      {...({ top: 0, left: 0 } as object)}
-      width={termCols}
-      height={termRows}
-      alignItems={anchor.alignItems}
-      justifyContent={anchor.justifyContent}
+      flexDirection="column"
+      gap={1}
+      width={TOAST_WIDTH}
+      // `alignItems` on a column flex controls the cross-axis
+      // (horizontal) — right-aligns each toast inside the 40-col stack so
+      // short messages don't float awkwardly.
+      alignItems="flex-end"
     >
-      <Box
-        flexDirection="column"
-        gap={1}
-        marginTop={isTop ? EDGE_GUTTER : 0}
-        marginBottom={isTop ? 0 : EDGE_GUTTER}
-        marginLeft={isRight ? 0 : EDGE_GUTTER}
-        marginRight={isRight ? EDGE_GUTTER : 0}
-        width={TOAST_WIDTH}
-        // `alignItems` on a column flex controls the cross-axis
-        // (horizontal) — this right- or left-aligns each toast inside
-        // the 40-col stack so short messages don't float awkwardly.
-        alignItems={isRight ? 'flex-end' : 'flex-start'}
-      >
-        {toasts.map((t) => (
-          <Alert key={t.id} variant={t.variant}>
-            {t.message}
-          </Alert>
-        ))}
-      </Box>
+      {toasts.map((t) => (
+        <Alert key={t.id} variant={t.variant}>
+          {t.message}
+        </Alert>
+      ))}
     </Box>
   );
 }

--- a/apps/cli/src/components/TopRightOverlay.tsx
+++ b/apps/cli/src/components/TopRightOverlay.tsx
@@ -24,10 +24,12 @@ const EDGE_GUTTER = 2;
 const TOP_ROW = 1;
 
 interface TopRightOverlayProps {
-  hidePlanIndicator?: boolean;
+  showPlanIndicator?: boolean;
 }
 
-export function TopRightOverlay({ hidePlanIndicator }: TopRightOverlayProps) {
+export function TopRightOverlay({
+  showPlanIndicator = true,
+}: TopRightOverlayProps) {
   const { termCols, termRows } = useLayout();
 
   return (
@@ -49,7 +51,7 @@ export function TopRightOverlay({ hidePlanIndicator }: TopRightOverlayProps) {
         gap={1}
       >
         <AsyncOpsContent />
-        {!hidePlanIndicator && <PlanIndicatorSection />}
+        {showPlanIndicator && <PlanIndicatorSection />}
         <ToastStack />
       </Box>
     </Box>

--- a/apps/cli/src/components/TopRightOverlay.tsx
+++ b/apps/cli/src/components/TopRightOverlay.tsx
@@ -1,0 +1,57 @@
+import { Box } from 'ink';
+import { useLayout } from '../context/LayoutContext.js';
+import { AsyncOpsContent } from './AsyncOpsIndicator.js';
+import { PlanIndicatorSection } from './PlanIndicator.js';
+import { ToastStack } from './ToastContainer.js';
+
+// Unified top-right overlay. A single full-screen `position="absolute"`
+// box anchors a column into the top-right corner; inside it, three
+// stacked sections flow naturally:
+//
+//   1. Async-ops spinner (while operations are in flight)
+//   2. Plan indicator    (while the current PR has queued comments)
+//   3. Toast stack        (transient status messages)
+//
+// Each section renders `null` when it has nothing to show, and `gap`
+// only spaces the sections that actually render — so with no async ops
+// the plan sits at the very top, and it drops down a row when a spinner
+// appears above it. This replaces three independently-positioned
+// overlays that previously overlapped in the same corner.
+//
+// Gutter matches the old EDGE_GUTTER/TOP_ROW so the stack lines up on
+// the pane's title row, two cols from the right edge.
+const EDGE_GUTTER = 2;
+const TOP_ROW = 1;
+
+interface TopRightOverlayProps {
+  hidePlanIndicator?: boolean;
+}
+
+export function TopRightOverlay({ hidePlanIndicator }: TopRightOverlayProps) {
+  const { termCols, termRows } = useLayout();
+
+  return (
+    <Box
+      position="absolute"
+      // Ink types lag the runtime for offsets — greppable cast, same as
+      // Modal.
+      {...({ top: 0, left: 0 } as object)}
+      width={termCols}
+      height={termRows}
+      alignItems="flex-start"
+      justifyContent="flex-end"
+    >
+      <Box
+        flexDirection="column"
+        marginTop={TOP_ROW}
+        marginRight={EDGE_GUTTER}
+        alignItems="flex-end"
+        gap={1}
+      >
+        <AsyncOpsContent />
+        {!hidePlanIndicator && <PlanIndicatorSection />}
+        <ToastStack />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/cli/src/context/PlanContext.tsx
+++ b/apps/cli/src/context/PlanContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+import { usePlanStore } from '../plan/plan-store.js';
+import type { PlanItem } from '../plan/plan-types.js';
+
+export interface PlanValue {
+  /** Reactive snapshot — read to subscribe; mutate via the methods. */
+  snapshot: ReadonlyMap<number, PlanItem[]>;
+  add: (prId: number, item: PlanItem) => void;
+  remove: (prId: number, kind: PlanItem['kind'], id: string) => void;
+  has: (prId: number, kind: PlanItem['kind'], id: string) => boolean;
+  toggle: (prId: number, item: PlanItem) => boolean;
+  annotate: (
+    prId: number,
+    kind: PlanItem['kind'],
+    id: string,
+    annotation: string
+  ) => void;
+  list: (prId: number) => PlanItem[];
+  count: (prId: number) => number;
+  clear: (prId: number) => void;
+}
+
+// Single-context: the API is small and the only reactive state is the
+// snapshot Map. Mirrors AsyncOpsContext — consumers read the snapshot
+// for the indicator and call the imperative methods from input handlers.
+const PlanContext = createContext<PlanValue | null>(null);
+
+export function PlanProvider({ children }: { children: ReactNode }) {
+  const value = usePlanStore();
+  return <PlanContext.Provider value={value}>{children}</PlanContext.Provider>;
+}
+
+export function usePlan(): PlanValue {
+  const ctx = useContext(PlanContext);
+  if (!ctx) throw new Error('usePlan must be used within PlanProvider');
+  return ctx;
+}

--- a/apps/cli/src/hooks/usePaneReducer.ts
+++ b/apps/cli/src/hooks/usePaneReducer.ts
@@ -41,6 +41,18 @@ export interface PaneState {
   // Review confirm
   reviewConfirm: { pr: PullRequestInfo; selectedOption: number } | null;
   reviewInstruction: string;
+
+  // Plan checkout ("add-to-cart")
+  // Where Esc returns from the checkout pane.
+  priorPaneMode: PaneMode;
+  // Selected row in the checkout checklist.
+  planCheckoutIndex: number;
+  // planItemKey of the item whose annotation is being edited (in the
+  // diff viewer Shift+A composer or the checkout pane), or null.
+  annotatingPlanKey: string | null;
+  annotationBuffer: string;
+  // In State A (running agent) the checkout pane asks inject vs restart.
+  planCheckoutTarget: 'inject' | 'new-session' | null;
 }
 
 export const initialState: PaneState = {
@@ -61,6 +73,11 @@ export const initialState: PaneState = {
   generalCommentsScrollOffset: 0,
   reviewConfirm: null,
   reviewInstruction: '',
+  priorPaneMode: 'terminal',
+  planCheckoutIndex: 0,
+  annotatingPlanKey: null,
+  annotationBuffer: '',
+  planCheckoutTarget: null,
 };
 
 // ── Actions ──────────────────────────────────────────────────────
@@ -92,7 +109,15 @@ export type PaneAction =
       type: 'SET_REVIEW_CONFIRM';
       value: { pr: PullRequestInfo; selectedOption: number } | null;
     }
-  | { type: 'SET_REVIEW_INSTRUCTION'; updater: Updater<string> };
+  | { type: 'SET_REVIEW_INSTRUCTION'; updater: Updater<string> }
+  | { type: 'SET_PRIOR_PANE_MODE'; mode: PaneMode }
+  | { type: 'SET_PLAN_CHECKOUT_INDEX'; updater: Updater<number> }
+  | { type: 'SET_ANNOTATING_PLAN_KEY'; key: string | null }
+  | { type: 'SET_ANNOTATION_BUFFER'; updater: Updater<string> }
+  | {
+      type: 'SET_PLAN_CHECKOUT_TARGET';
+      value: 'inject' | 'new-session' | null;
+    };
 
 export function paneReducer(state: PaneState, action: PaneAction): PaneState {
   switch (action.type) {
@@ -163,6 +188,22 @@ export function paneReducer(state: PaneState, action: PaneAction): PaneState {
         ...state,
         reviewInstruction: resolve(action.updater, state.reviewInstruction),
       };
+    case 'SET_PRIOR_PANE_MODE':
+      return { ...state, priorPaneMode: action.mode };
+    case 'SET_PLAN_CHECKOUT_INDEX':
+      return {
+        ...state,
+        planCheckoutIndex: resolve(action.updater, state.planCheckoutIndex),
+      };
+    case 'SET_ANNOTATING_PLAN_KEY':
+      return { ...state, annotatingPlanKey: action.key };
+    case 'SET_ANNOTATION_BUFFER':
+      return {
+        ...state,
+        annotationBuffer: resolve(action.updater, state.annotationBuffer),
+      };
+    case 'SET_PLAN_CHECKOUT_TARGET':
+      return { ...state, planCheckoutTarget: action.value };
   }
 }
 
@@ -188,6 +229,11 @@ export interface PaneActions {
     value: { pr: PullRequestInfo; selectedOption: number } | null
   ) => void;
   setReviewInstruction: (updater: Updater<string>) => void;
+  setPriorPaneMode: (mode: PaneMode) => void;
+  setPlanCheckoutIndex: (updater: Updater<number>) => void;
+  setAnnotatingPlanKey: (key: string | null) => void;
+  setAnnotationBuffer: (updater: Updater<string>) => void;
+  setPlanCheckoutTarget: (value: 'inject' | 'new-session' | null) => void;
 }
 
 /** Combined type for input handlers: read state + call setters. */
@@ -269,6 +315,16 @@ export function usePaneReducer(
         dispatch({ type: 'SET_REVIEW_CONFIRM', value }),
       setReviewInstruction: (updater) =>
         dispatch({ type: 'SET_REVIEW_INSTRUCTION', updater }),
+      setPriorPaneMode: (mode) =>
+        dispatch({ type: 'SET_PRIOR_PANE_MODE', mode }),
+      setPlanCheckoutIndex: (updater) =>
+        dispatch({ type: 'SET_PLAN_CHECKOUT_INDEX', updater }),
+      setAnnotatingPlanKey: (key) =>
+        dispatch({ type: 'SET_ANNOTATING_PLAN_KEY', key }),
+      setAnnotationBuffer: (updater) =>
+        dispatch({ type: 'SET_ANNOTATION_BUFFER', updater }),
+      setPlanCheckoutTarget: (value) =>
+        dispatch({ type: 'SET_PLAN_CHECKOUT_TARGET', value }),
     }),
     []
   );

--- a/apps/cli/src/keybindings/controls-data.ts
+++ b/apps/cli/src/keybindings/controls-data.ts
@@ -11,6 +11,7 @@ const CONTEXT_LABELS: Record<InputContext, string> = {
   'confirm-delete': 'Confirm Delete',
   'diff-file-list': 'Diff File List',
   'diff-viewer': 'Diff Viewer',
+  'plan-checkout': 'Plan Checkout',
   controls: 'Controls',
 };
 
@@ -18,6 +19,7 @@ const CONTEXT_ORDER: InputContext[] = [
   'sidebar',
   'diff-viewer',
   'diff-file-list',
+  'plan-checkout',
   'settings',
   'branch-picker',
   'confirm',

--- a/apps/cli/src/keybindings/registry.spec.ts
+++ b/apps/cli/src/keybindings/registry.spec.ts
@@ -269,3 +269,101 @@ describe('registry — diff-file-list comment actions', () => {
     );
   });
 });
+
+// ── Plan ("add-to-cart") bindings ─────────────────────────────────
+
+// Synthesize a keypress from a descriptor so we can feed real bindings
+// back through the resolver. Mirrors how Ink reports keys: uppercase
+// letters carry an implicit shift.
+function keypressFromDescriptor(desc: {
+  input?: string;
+  flags?: Record<string, boolean>;
+  ctrl?: boolean;
+  shift?: boolean;
+  meta?: boolean;
+}): { input: string; key: Key } {
+  const key = makeKey({
+    ...(desc.flags ?? {}),
+    ctrl: desc.ctrl === true,
+    meta: desc.meta === true,
+    shift:
+      desc.shift === true ||
+      (desc.input !== undefined && /[A-Z]/.test(desc.input)),
+  });
+  return { input: desc.input ?? '', key };
+}
+
+describe('registry — plan bindings', () => {
+  const requiredActions: ActionId[] = [
+    'diff-viewer.plan-toggle',
+    'diff-viewer.plan-annotate',
+    'diff-viewer.plan-checkout',
+    'diff-file-list.plan-toggle',
+    'diff-file-list.plan-annotate',
+    'diff-file-list.plan-checkout',
+    'plan-checkout.navigate-down',
+    'plan-checkout.navigate-up',
+    'plan-checkout.toggle-include',
+    'plan-checkout.annotate',
+    'plan-checkout.send',
+    'plan-checkout.back',
+  ];
+
+  it.each(requiredActions)('registers %s in ACTIONS', (id) => {
+    expect(actionExists(id)).toBe(true);
+  });
+
+  it('Normie: a=add, Shift+A=annotate, c=checkout in the diff viewer', () => {
+    expect(resolveInPreset('a', makeKey(), 'diff-viewer', NORMIE_PRESET)).toBe(
+      'diff-viewer.plan-toggle'
+    );
+    expect(
+      resolveInPreset('A', makeKey({ shift: true }), 'diff-viewer', NORMIE_PRESET)
+    ).toBe('diff-viewer.plan-annotate');
+    expect(resolveInPreset('c', makeKey(), 'diff-viewer', NORMIE_PRESET)).toBe(
+      'diff-viewer.plan-checkout'
+    );
+  });
+
+  it('Vim: checkout is o (c stays next-comment)', () => {
+    expect(resolveInPreset('o', makeKey(), 'diff-viewer', VIM_PRESET)).toBe(
+      'diff-viewer.plan-checkout'
+    );
+    // Regression: vim `c` must still be comment nav, not checkout.
+    expect(resolveInPreset('c', makeKey(), 'diff-viewer', VIM_PRESET)).toBe(
+      'diff-viewer.next-comment'
+    );
+  });
+
+  // Exhaustive guard: every binding in every context/preset must resolve
+  // to exactly one action (no intra-context collisions). Catches future
+  // key clashes automatically, including the vim `c`/checkout trap.
+  const CONTEXTS = [
+    'sidebar',
+    'settings',
+    'branch-picker',
+    'confirm',
+    'confirm-delete',
+    'diff-file-list',
+    'diff-viewer',
+    'plan-checkout',
+    'controls',
+  ] as const;
+
+  for (const preset of [NORMIE_PRESET, VIM_PRESET]) {
+    for (const context of CONTEXTS) {
+      const contextActions = ACTIONS.filter((a) => a.context === context);
+      for (const action of contextActions) {
+        const descriptors = preset.bindings[action.id] ?? [];
+        for (const [di, desc] of descriptors.entries()) {
+          it(`${preset.id}/${context}: ${action.id}[${di}] has no conflict`, () => {
+            const { input, key } = keypressFromDescriptor(desc);
+            expect(
+              findConflict(input, key, context, preset.bindings, ACTIONS, action.id)
+            ).toBeNull();
+          });
+        }
+      }
+    }
+  }
+});

--- a/apps/cli/src/keybindings/registry.ts
+++ b/apps/cli/src/keybindings/registry.ts
@@ -41,6 +41,7 @@ export type InputContext =
   | 'confirm-delete'
   | 'diff-file-list'
   | 'diff-viewer'
+  | 'plan-checkout'
   | 'controls';
 
 /** A bindable action in the application */
@@ -299,6 +300,27 @@ export const ACTIONS = [
     label: 'Resolve/reopen thread',
     context: 'diff-file-list',
   },
+  {
+    id: 'diff-file-list.plan-toggle',
+    label: 'Add/remove comment in plan',
+    context: 'diff-file-list',
+    hintLabel: 'add to plan',
+    showInHints: true,
+    vcsOnly: true,
+  },
+  {
+    id: 'diff-file-list.plan-annotate',
+    label: 'Add to plan with note',
+    context: 'diff-file-list',
+  },
+  {
+    id: 'diff-file-list.plan-checkout',
+    label: 'Checkout plan',
+    context: 'diff-file-list',
+    hintLabel: 'checkout plan',
+    showInHints: true,
+    vcsOnly: true,
+  },
 
   // ── Diff Viewer ──
   {
@@ -379,7 +401,52 @@ export const ACTIONS = [
     label: 'Resolve/reopen thread',
     context: 'diff-viewer',
   },
+  {
+    id: 'diff-viewer.plan-toggle',
+    label: 'Add/remove comment in plan',
+    context: 'diff-viewer',
+    hintLabel: 'add to plan',
+    showInHints: true,
+    vcsOnly: true,
+  },
+  {
+    id: 'diff-viewer.plan-annotate',
+    label: 'Add to plan with note',
+    context: 'diff-viewer',
+  },
+  {
+    id: 'diff-viewer.plan-checkout',
+    label: 'Checkout plan',
+    context: 'diff-viewer',
+    hintLabel: 'checkout plan',
+    showInHints: true,
+    vcsOnly: true,
+  },
   { id: 'diff-viewer.back', label: 'Back', context: 'diff-viewer' },
+
+  // ── Plan Checkout ──
+  {
+    id: 'plan-checkout.navigate-down',
+    label: 'Navigate down',
+    context: 'plan-checkout',
+  },
+  {
+    id: 'plan-checkout.navigate-up',
+    label: 'Navigate up',
+    context: 'plan-checkout',
+  },
+  {
+    id: 'plan-checkout.toggle-include',
+    label: 'Include/exclude item',
+    context: 'plan-checkout',
+  },
+  {
+    id: 'plan-checkout.annotate',
+    label: 'Edit item note',
+    context: 'plan-checkout',
+  },
+  { id: 'plan-checkout.send', label: 'Send to agent', context: 'plan-checkout' },
+  { id: 'plan-checkout.back', label: 'Back', context: 'plan-checkout' },
 
   // ── Controls ──
   { id: 'controls.navigate-down', label: 'Navigate down', context: 'controls' },
@@ -462,6 +529,9 @@ export const NORMIE_PRESET: KeybindPreset = {
     'diff-file-list.prev-section': [{ ctrl: true, flags: { upArrow: true } }],
     'diff-file-list.reply-to-thread': [{ input: 'r' }],
     'diff-file-list.toggle-thread-resolved': [{ input: 'v' }],
+    'diff-file-list.plan-toggle': [{ input: 'a' }],
+    'diff-file-list.plan-annotate': [{ input: 'A', shift: true }],
+    'diff-file-list.plan-checkout': [{ input: 'c' }],
 
     // Diff Viewer
     'diff-viewer.scroll-down': [{ flags: { downArrow: true } }],
@@ -482,7 +552,18 @@ export const NORMIE_PRESET: KeybindPreset = {
     'diff-viewer.editor-edit': [{ input: 'E', shift: true }],
     'diff-viewer.reply-to-thread': [{ input: 'r' }],
     'diff-viewer.toggle-thread-resolved': [{ input: 'v' }],
+    'diff-viewer.plan-toggle': [{ input: 'a' }],
+    'diff-viewer.plan-annotate': [{ input: 'A', shift: true }],
+    'diff-viewer.plan-checkout': [{ input: 'c' }],
     'diff-viewer.back': [{ flags: { escape: true } }],
+
+    // Plan Checkout
+    'plan-checkout.navigate-down': [{ flags: { downArrow: true } }],
+    'plan-checkout.navigate-up': [{ flags: { upArrow: true } }],
+    'plan-checkout.toggle-include': [{ input: ' ' }],
+    'plan-checkout.annotate': [{ input: 'a' }],
+    'plan-checkout.send': [{ flags: { return: true } }],
+    'plan-checkout.back': [{ flags: { escape: true } }],
 
     // Controls
     'controls.navigate-down': [{ flags: { downArrow: true } }],
@@ -562,6 +643,9 @@ export const VIM_PRESET: KeybindPreset = {
     'diff-file-list.prev-section': [{ ctrl: true, flags: { upArrow: true } }],
     'diff-file-list.reply-to-thread': [{ input: 'r' }],
     'diff-file-list.toggle-thread-resolved': [{ input: 'v' }],
+    'diff-file-list.plan-toggle': [{ input: 'a' }],
+    'diff-file-list.plan-annotate': [{ input: 'A' }],
+    'diff-file-list.plan-checkout': [{ input: 'o' }],
 
     // Diff Viewer
     'diff-viewer.scroll-down': [{ input: 'j' }, { flags: { downArrow: true } }],
@@ -588,7 +672,20 @@ export const VIM_PRESET: KeybindPreset = {
     'diff-viewer.editor-edit': [{ input: 'E' }],
     'diff-viewer.reply-to-thread': [{ input: 'r' }],
     'diff-viewer.toggle-thread-resolved': [{ input: 'v' }],
+    // Vim binds `c`/`C` to next/prev-comment, so checkout uses `o`
+    // ("check-o-ut") to avoid clobbering comment navigation.
+    'diff-viewer.plan-toggle': [{ input: 'a' }],
+    'diff-viewer.plan-annotate': [{ input: 'A' }],
+    'diff-viewer.plan-checkout': [{ input: 'o' }],
     'diff-viewer.back': [{ flags: { escape: true } }],
+
+    // Plan Checkout
+    'plan-checkout.navigate-down': [{ input: 'j' }, { flags: { downArrow: true } }],
+    'plan-checkout.navigate-up': [{ input: 'k' }, { flags: { upArrow: true } }],
+    'plan-checkout.toggle-include': [{ input: ' ' }],
+    'plan-checkout.annotate': [{ input: 'a' }],
+    'plan-checkout.send': [{ flags: { return: true } }],
+    'plan-checkout.back': [{ flags: { escape: true } }],
 
     // Controls
     'controls.navigate-down': [{ input: 'j' }, { flags: { downArrow: true } }],

--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -6,6 +6,7 @@ import { githubProvider } from '@kirby/vcs-github';
 import { DeleteConfirmModal } from './components/DeleteConfirmModal.js';
 import { ToastContainer } from './components/ToastContainer.js';
 import { AsyncOpsIndicator } from './components/AsyncOpsIndicator.js';
+import { PlanIndicator } from './components/PlanIndicator.js';
 import { OnboardingWizard } from './components/OnboardingWizard.js';
 import { killAll } from './pty-registry.js';
 import { settlePendingRuns } from './hooks/useAsyncOperation.js';
@@ -13,6 +14,7 @@ import { ConfigProvider, useConfig } from './context/ConfigContext.js';
 import { KeybindProvider } from './context/KeybindContext.js';
 import { NavProvider, useNavState } from './context/NavContext.js';
 import { AsyncOpsProvider } from './context/AsyncOpsContext.js';
+import { PlanProvider } from './context/PlanContext.js';
 import { LayoutProvider, useLayout } from './context/LayoutContext.js';
 import { ModalProvider } from './context/ModalContext.js';
 import { useDeleteConfirmState } from './context/ModalContext.js';
@@ -92,6 +94,7 @@ function App() {
         />
       )}
       <AsyncOpsIndicator />
+      <PlanIndicator />
       <ToastContainer />
     </Box>
   );
@@ -129,15 +132,17 @@ render(
       <LayoutProvider>
         <NavProvider>
           <AsyncOpsProvider>
-            <ModalProvider>
-              <ToastProvider>
-                <SessionProvider>
-                  <SidebarProvider>
-                    <App />
-                  </SidebarProvider>
-                </SessionProvider>
-              </ToastProvider>
-            </ModalProvider>
+            <PlanProvider>
+              <ModalProvider>
+                <ToastProvider>
+                  <SessionProvider>
+                    <SidebarProvider>
+                      <App />
+                    </SidebarProvider>
+                  </SessionProvider>
+                </ToastProvider>
+              </ModalProvider>
+            </PlanProvider>
           </AsyncOpsProvider>
         </NavProvider>
       </LayoutProvider>

--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -4,9 +4,6 @@ import type { VcsProvider } from '@kirby/vcs-core';
 import { azureDevOpsProvider } from '@kirby/vcs-azure-devops';
 import { githubProvider } from '@kirby/vcs-github';
 import { DeleteConfirmModal } from './components/DeleteConfirmModal.js';
-import { ToastContainer } from './components/ToastContainer.js';
-import { AsyncOpsIndicator } from './components/AsyncOpsIndicator.js';
-import { PlanIndicator } from './components/PlanIndicator.js';
 import { OnboardingWizard } from './components/OnboardingWizard.js';
 import { killAll } from './pty-registry.js';
 import { settlePendingRuns } from './hooks/useAsyncOperation.js';
@@ -93,9 +90,6 @@ function App() {
           confirmInput={deleteConfirm.confirmInput}
         />
       )}
-      <AsyncOpsIndicator />
-      <PlanIndicator />
-      <ToastContainer />
     </Box>
   );
 }

--- a/apps/cli/src/plan/checkout-orchestrator.spec.ts
+++ b/apps/cli/src/plan/checkout-orchestrator.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PullRequestInfo } from '@kirby/vcs-core';
+
+// Mock the PTY registry and worktree manager so the orchestrator's
+// branching is observable without spawning real processes.
+const hasSession = vi.fn();
+const getSession = vi.fn();
+const spawnSession = vi.fn();
+vi.mock('../pty-registry.js', () => ({
+  hasSession: (n: string) => hasSession(n),
+  getSession: (n: string) => getSession(n),
+  spawnSession: (...a: unknown[]) => spawnSession(...a),
+}));
+
+const branchToSessionName = vi.fn((b: string) => `sess-${b}`);
+const createWorktree = vi.fn();
+vi.mock('@kirby/worktree-manager', () => ({
+  branchToSessionName: (b: string) => branchToSessionName(b),
+  createWorktree: (b: string) => createWorktree(b),
+}));
+
+import { checkoutPlan } from './checkout-orchestrator.js';
+
+const pr = { id: 7, sourceBranch: 'feature/x' } as PullRequestInfo;
+
+function deps(mode: 'inject' | 'new-session', flashStatus = vi.fn()) {
+  return {
+    pr,
+    prompt: 'Resolve these PR review comments:\n\n### 1. a.ts:1\n@a: b',
+    paneCols: 80,
+    paneRows: 24,
+    mode,
+    flashStatus,
+  };
+}
+
+describe('checkoutPlan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createWorktree.mockResolvedValue('/wt/feature-x');
+  });
+
+  it('State A / inject: writes to the running PTY, never spawns', async () => {
+    hasSession.mockReturnValue(true);
+    const write = vi.fn();
+    getSession.mockReturnValue({ pty: { write }, exited: false });
+
+    const result = await checkoutPlan(deps('inject'));
+
+    expect(result).toBe('injected');
+    expect(write).toHaveBeenCalledTimes(1);
+    // Prompt is submitted with a trailing carriage return, no shell-quoting.
+    expect(write).toHaveBeenCalledWith(expect.stringMatching(/\r$/));
+    expect(spawnSession).not.toHaveBeenCalled();
+    expect(createWorktree).not.toHaveBeenCalled();
+  });
+
+  it('State A / inject: fails when the session has exited', async () => {
+    hasSession.mockReturnValue(true);
+    getSession.mockReturnValue({ pty: { write: vi.fn() }, exited: true });
+    const flash = vi.fn();
+
+    const result = await checkoutPlan(deps('inject', flash));
+
+    expect(result).toBe('failed');
+    expect(spawnSession).not.toHaveBeenCalled();
+    expect(flash).toHaveBeenCalled();
+  });
+
+  it('State A / new-session: respawns in the existing worktree', async () => {
+    hasSession.mockReturnValue(true);
+
+    const result = await checkoutPlan(deps('new-session'));
+
+    expect(result).toBe('spawned');
+    expect(createWorktree).toHaveBeenCalledWith('feature/x');
+    expect(spawnSession).toHaveBeenCalledTimes(1);
+    const args = spawnSession.mock.calls[0];
+    expect(args[0]).toBe('sess-feature/x');
+    // Seed command must NOT use --continue (else the plan is swallowed).
+    expect(args[2][1]).not.toContain('--continue');
+    expect(args[2][1]).toContain("claude '");
+  });
+
+  it('States B/C: no running agent → create worktree + spawn', async () => {
+    hasSession.mockReturnValue(false);
+
+    const result = await checkoutPlan(deps('new-session'));
+
+    expect(result).toBe('spawned');
+    expect(createWorktree).toHaveBeenCalledWith('feature/x');
+    expect(spawnSession).toHaveBeenCalledTimes(1);
+    expect(spawnSession.mock.calls[0][5]).toBe('/wt/feature-x');
+  });
+
+  it('fails when the worktree cannot be created', async () => {
+    hasSession.mockReturnValue(false);
+    createWorktree.mockResolvedValue(null);
+    const flash = vi.fn();
+
+    const result = await checkoutPlan(deps('new-session', flash));
+
+    expect(result).toBe('failed');
+    expect(spawnSession).not.toHaveBeenCalled();
+    expect(flash).toHaveBeenCalled();
+  });
+
+  it('sanitizes quotes in the seed command', async () => {
+    hasSession.mockReturnValue(false);
+
+    await checkoutPlan({ ...deps('new-session'), prompt: `it's "quoted"` });
+
+    const cmd = spawnSession.mock.calls[0][2][1] as string;
+    expect(cmd).not.toContain('"');
+    expect(cmd).toBe("claude 'its quoted'");
+  });
+});

--- a/apps/cli/src/plan/checkout-orchestrator.ts
+++ b/apps/cli/src/plan/checkout-orchestrator.ts
@@ -1,0 +1,92 @@
+import type { PullRequestInfo } from '@kirby/vcs-core';
+import { branchToSessionName, createWorktree } from '@kirby/worktree-manager';
+import { getSession, hasSession, spawnSession } from '../pty-registry.js';
+
+// ── Checkout orchestration ───────────────────────────────────────
+//
+// Forwards a composed plan prompt to a Claude agent in the PR's own
+// worktree. Three states (always one agent per worktree):
+//
+//   A. Agent already running → inject (pty.write, non-destructive) OR
+//      new-session (kill old + respawn), per `mode`.
+//   B. Worktree exists, no agent → spawn seeded with the plan.
+//   C. No worktree → create it, then spawn seeded with the plan.
+//
+// States B and C are unified because `createWorktree` is idempotent —
+// it returns the existing path in B and creates one in C.
+
+export type CheckoutResult = 'injected' | 'spawned' | 'failed';
+
+export interface CheckoutDeps {
+  pr: PullRequestInfo;
+  /** Composed plan prompt (see composePlanPrompt). */
+  prompt: string;
+  paneCols: number;
+  paneRows: number;
+  /** Only meaningful in State A (a running agent is present). */
+  mode: 'inject' | 'new-session';
+  flashStatus: (msg: string) => void;
+}
+
+/**
+ * Build the shell command that spawns a fresh Claude seeded with the
+ * plan. We deliberately do NOT use `claude --continue` here: continuing
+ * a prior conversation would swallow the seed prompt, and the whole
+ * point of checkout is to deliver the plan. Single-quote the sanitized
+ * prompt as one argv entry to `/bin/sh -c`.
+ */
+function seedCommand(prompt: string): string {
+  const safePrompt = prompt.replace(/['"]/g, '');
+  return `claude '${safePrompt}'`;
+}
+
+export async function checkoutPlan(deps: CheckoutDeps): Promise<CheckoutResult> {
+  const { pr, prompt, paneCols, paneRows, mode, flashStatus } = deps;
+  const name = branchToSessionName(pr.sourceBranch);
+
+  // ── State A: an agent is already running in this worktree ──
+  if (hasSession(name)) {
+    if (mode === 'inject') {
+      const entry = getSession(name);
+      if (!entry || entry.exited) {
+        flashStatus('Agent is no longer running');
+        return 'failed';
+      }
+      // Write directly into the running REPL. No shell-quoting — this
+      // is typed input, and the trailing CR submits it.
+      entry.pty.write(prompt + '\r');
+      return 'injected';
+    }
+    // new-session: reseed. spawnSession kills the same-name PTY first.
+    const worktreePath = await createWorktree(pr.sourceBranch);
+    if (!worktreePath) {
+      flashStatus(`Failed to resolve worktree for ${pr.sourceBranch}`);
+      return 'failed';
+    }
+    spawnSession(
+      name,
+      '/bin/sh',
+      ['-c', seedCommand(prompt)],
+      paneCols,
+      paneRows,
+      worktreePath
+    );
+    return 'spawned';
+  }
+
+  // ── States B & C: no running agent — ensure a worktree, then spawn ──
+  const worktreePath = await createWorktree(pr.sourceBranch);
+  if (!worktreePath) {
+    flashStatus(`Failed to create worktree for ${pr.sourceBranch}`);
+    return 'failed';
+  }
+  spawnSession(
+    name,
+    '/bin/sh',
+    ['-c', seedCommand(prompt)],
+    paneCols,
+    paneRows,
+    worktreePath
+  );
+  return 'spawned';
+}

--- a/apps/cli/src/plan/plan-store.spec.ts
+++ b/apps/cli/src/plan/plan-store.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { LocalPlanItem, RemotePlanItem } from './plan-types.js';
+import {
+  add,
+  annotate,
+  clear,
+  count,
+  has,
+  list,
+  remove,
+  toggle,
+  __resetPlanStoreForTest,
+} from './plan-store.js';
+
+function remote(id: string, over: Partial<RemotePlanItem> = {}): RemotePlanItem {
+  return {
+    kind: 'remote',
+    id,
+    file: 'a.ts',
+    line: 1,
+    body: `body-${id}`,
+    author: 'alice',
+    replies: [],
+    ...over,
+  };
+}
+
+function local(id: string, over: Partial<LocalPlanItem> = {}): LocalPlanItem {
+  return {
+    kind: 'local',
+    id,
+    file: 'b.ts',
+    line: 2,
+    body: `body-${id}`,
+    severity: 'minor',
+    ...over,
+  };
+}
+
+describe('plan-store', () => {
+  beforeEach(() => __resetPlanStoreForTest());
+
+  it('adds and lists items in insertion order', () => {
+    add(1, remote('t1'));
+    add(1, local('d1'));
+    expect(list(1).map((i) => i.id)).toEqual(['t1', 'd1']);
+    expect(count(1)).toBe(2);
+  });
+
+  it('dedupes by kind+id, re-snapshotting in place', () => {
+    add(1, remote('t1', { body: 'old' }));
+    add(1, local('t1')); // same id, different kind => distinct
+    add(1, remote('t1', { body: 'new' }));
+    const items = list(1);
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({ kind: 'remote', body: 'new' });
+    expect(items.map((i) => i.kind)).toEqual(['remote', 'local']);
+  });
+
+  it('toggle returns membership and flips it', () => {
+    expect(toggle(1, remote('t1'))).toBe(true);
+    expect(has(1, 'remote', 't1')).toBe(true);
+    expect(toggle(1, remote('t1'))).toBe(false);
+    expect(has(1, 'remote', 't1')).toBe(false);
+    expect(count(1)).toBe(0);
+  });
+
+  it('remove is a no-op for a missing item', () => {
+    add(1, remote('t1'));
+    remove(1, 'remote', 'nope');
+    expect(count(1)).toBe(1);
+  });
+
+  it('annotate sets and clears the note on an existing item', () => {
+    add(1, remote('t1'));
+    annotate(1, 'remote', 't1', '  use useMemo  ');
+    expect(list(1)[0].annotation).toBe('use useMemo');
+    annotate(1, 'remote', 't1', '   ');
+    expect(list(1)[0].annotation).toBeUndefined();
+  });
+
+  it('annotate is a no-op for a missing item', () => {
+    annotate(1, 'remote', 'nope', 'x');
+    expect(count(1)).toBe(0);
+  });
+
+  it('isolates plans per PR id', () => {
+    add(1, remote('t1'));
+    add(2, remote('t2'));
+    expect(list(1).map((i) => i.id)).toEqual(['t1']);
+    expect(list(2).map((i) => i.id)).toEqual(['t2']);
+    clear(1);
+    expect(count(1)).toBe(0);
+    expect(count(2)).toBe(1);
+  });
+
+  it('clear empties a PR plan', () => {
+    add(1, remote('t1'));
+    add(1, remote('t2'));
+    clear(1);
+    expect(list(1)).toEqual([]);
+  });
+});

--- a/apps/cli/src/plan/plan-store.spec.ts
+++ b/apps/cli/src/plan/plan-store.spec.ts
@@ -12,7 +12,10 @@ import {
   __resetPlanStoreForTest,
 } from './plan-store.js';
 
-function remote(id: string, over: Partial<RemotePlanItem> = {}): RemotePlanItem {
+function remote(
+  id: string,
+  over: Partial<RemotePlanItem> = {}
+): RemotePlanItem {
   return {
     kind: 'remote',
     id,
@@ -77,6 +80,22 @@ describe('plan-store', () => {
     expect(list(1)[0].annotation).toBe('use useMemo');
     annotate(1, 'remote', 't1', '   ');
     expect(list(1)[0].annotation).toBeUndefined();
+  });
+
+  it('re-adding an item preserves its existing annotation', () => {
+    add(1, remote('t1', { body: 'old' }));
+    annotate(1, 'remote', 't1', 'keep me');
+    // Re-snapshot from a fresh (annotation-less) source.
+    add(1, remote('t1', { body: 'new' }));
+    expect(list(1)[0].annotation).toBe('keep me');
+    expect(list(1)[0].body).toBe('new');
+  });
+
+  it('re-adding with an explicit annotation overrides the stored one', () => {
+    add(1, remote('t1'));
+    annotate(1, 'remote', 't1', 'old note');
+    add(1, remote('t1', { annotation: 'new note' }));
+    expect(list(1)[0].annotation).toBe('new note');
   });
 
   it('annotate is a no-op for a missing item', () => {

--- a/apps/cli/src/plan/plan-store.ts
+++ b/apps/cli/src/plan/plan-store.ts
@@ -1,0 +1,136 @@
+import { useSyncExternalStore } from 'react';
+import type { PlanItem } from './plan-types.js';
+import { planItemKey } from './plan-types.js';
+
+// ── Module-local store ───────────────────────────────────────────
+//
+// Same pattern as useAsyncOperation.ts: a module-local, copy-on-write
+// Map is the authority; consumers read it through useSyncExternalStore.
+// Every mutation replaces the Map (and the affected array) with a new
+// reference so React detects the change by identity and re-renders.
+//
+// The plan is per-PR and in-memory only — keyed by numeric PR id,
+// never persisted to disk, and cleared after a successful checkout.
+
+let plans = new Map<number, PlanItem[]>();
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+function getSnapshot(): ReadonlyMap<number, PlanItem[]> {
+  return plans;
+}
+
+function notify(): void {
+  for (const cb of listeners) cb();
+}
+
+/** Copy-on-write helper: replace one PR's array, keeping others intact. */
+function setItems(prId: number, items: PlanItem[]): void {
+  plans = new Map(plans);
+  if (items.length === 0) plans.delete(prId);
+  else plans.set(prId, items);
+  notify();
+}
+
+/**
+ * Add (or re-snapshot) an item. If an item with the same identity
+ * (kind + id) already exists it is replaced in place, preserving order
+ * — this keeps the snapshot fresh without reordering the cart.
+ */
+export function add(prId: number, item: PlanItem): void {
+  const cur = plans.get(prId) ?? [];
+  const key = planItemKey(item.kind, item.id);
+  const idx = cur.findIndex((i) => planItemKey(i.kind, i.id) === key);
+  const next = cur.slice();
+  if (idx >= 0) next[idx] = item;
+  else next.push(item);
+  setItems(prId, next);
+}
+
+export function remove(prId: number, kind: PlanItem['kind'], id: string): void {
+  const cur = plans.get(prId);
+  if (!cur) return;
+  const key = planItemKey(kind, id);
+  const next = cur.filter((i) => planItemKey(i.kind, i.id) !== key);
+  if (next.length !== cur.length) setItems(prId, next);
+}
+
+export function has(prId: number, kind: PlanItem['kind'], id: string): boolean {
+  const cur = plans.get(prId);
+  if (!cur) return false;
+  const key = planItemKey(kind, id);
+  return cur.some((i) => planItemKey(i.kind, i.id) === key);
+}
+
+/** Toggle membership. Returns the new membership state (true = in plan). */
+export function toggle(prId: number, item: PlanItem): boolean {
+  if (has(prId, item.kind, item.id)) {
+    remove(prId, item.kind, item.id);
+    return false;
+  }
+  add(prId, item);
+  return true;
+}
+
+/** Set (or clear) the annotation on an existing item. No-op if absent. */
+export function annotate(
+  prId: number,
+  kind: PlanItem['kind'],
+  id: string,
+  annotation: string
+): void {
+  const cur = plans.get(prId);
+  if (!cur) return;
+  const key = planItemKey(kind, id);
+  const idx = cur.findIndex((i) => planItemKey(i.kind, i.id) === key);
+  if (idx < 0) return;
+  const trimmed = annotation.trim();
+  const next = cur.slice();
+  const updated = { ...next[idx] };
+  if (trimmed) updated.annotation = trimmed;
+  else delete updated.annotation;
+  next[idx] = updated;
+  setItems(prId, next);
+}
+
+export function list(prId: number): PlanItem[] {
+  return plans.get(prId) ?? [];
+}
+
+export function count(prId: number): number {
+  return plans.get(prId)?.length ?? 0;
+}
+
+/** Clear a PR's plan (called after a successful checkout). */
+export function clear(prId: number): void {
+  if (plans.has(prId)) setItems(prId, []);
+}
+
+/** Test-only: drop all plans and notify subscribers. */
+export function __resetPlanStoreForTest(): void {
+  plans = new Map();
+  notify();
+}
+
+// ── Hook ─────────────────────────────────────────────────────────
+
+export function usePlanStore() {
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot);
+  return {
+    snapshot,
+    add,
+    remove,
+    has,
+    toggle,
+    annotate,
+    list,
+    count,
+    clear,
+  };
+}

--- a/apps/cli/src/plan/plan-store.ts
+++ b/apps/cli/src/plan/plan-store.ts
@@ -41,15 +41,22 @@ function setItems(prId: number, items: PlanItem[]): void {
 /**
  * Add (or re-snapshot) an item. If an item with the same identity
  * (kind + id) already exists it is replaced in place, preserving order
- * — this keeps the snapshot fresh without reordering the cart.
+ * — this keeps the snapshot fresh without reordering the cart. An
+ * existing user annotation is preserved when the incoming snapshot
+ * carries none, so re-adding an item never silently drops its note.
  */
 export function add(prId: number, item: PlanItem): void {
   const cur = plans.get(prId) ?? [];
   const key = planItemKey(item.kind, item.id);
   const idx = cur.findIndex((i) => planItemKey(i.kind, i.id) === key);
   const next = cur.slice();
-  if (idx >= 0) next[idx] = item;
-  else next.push(item);
+  if (idx >= 0) {
+    const prev = next[idx]!;
+    next[idx] =
+      item.annotation === undefined && prev.annotation !== undefined
+        ? { ...item, annotation: prev.annotation }
+        : item;
+  } else next.push(item);
   setItems(prId, next);
 }
 

--- a/apps/cli/src/plan/plan-types.spec.ts
+++ b/apps/cli/src/plan/plan-types.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import type { RemoteCommentThread } from '@kirby/vcs-core';
+import type { ReviewComment } from '@kirby/review-comments';
+import { planItemKey, snapshotLocal, snapshotRemote } from './plan-types.js';
+
+function thread(over: Partial<RemoteCommentThread> = {}): RemoteCommentThread {
+  return {
+    id: 't1',
+    file: 'a.ts',
+    lineStart: 10,
+    lineEnd: 10,
+    side: 'RIGHT',
+    isResolved: false,
+    isOutdated: false,
+    canResolve: true,
+    comments: [
+      { id: 'c1', author: 'alice', body: 'root', createdAt: '2026-01-01' },
+      { id: 'c2', author: 'bob', body: 'reply', createdAt: '2026-01-02' },
+    ],
+    ...over,
+  };
+}
+
+function draft(over: Partial<ReviewComment> = {}): ReviewComment {
+  return {
+    id: 'd1',
+    file: 'b.ts',
+    lineStart: 5,
+    lineEnd: 5,
+    severity: 'major',
+    body: 'draft body',
+    side: 'RIGHT',
+    status: 'draft',
+    createdAt: '2026-01-01',
+    ...over,
+  };
+}
+
+describe('planItemKey', () => {
+  it('composes kind:id', () => {
+    expect(planItemKey('remote', 't1')).toBe('remote:t1');
+    expect(planItemKey('local', 'd1')).toBe('local:d1');
+  });
+});
+
+describe('snapshotRemote', () => {
+  it('copies root body/author and replies by value', () => {
+    const item = snapshotRemote(thread());
+    expect(item).toMatchObject({
+      kind: 'remote',
+      id: 't1',
+      file: 'a.ts',
+      line: 10,
+      body: 'root',
+      author: 'alice',
+      replies: [{ author: 'bob', body: 'reply' }],
+    });
+    expect(item.annotation).toBeUndefined();
+  });
+
+  it('does not mutate when the source thread changes afterwards', () => {
+    const t = thread();
+    const item = snapshotRemote(t);
+    t.comments[0].body = 'CHANGED';
+    t.comments.push({ id: 'c3', author: 'carol', body: 'late', createdAt: 'x' });
+    expect(item.body).toBe('root');
+    expect(item.replies).toHaveLength(1);
+  });
+
+  it('attaches annotation when provided', () => {
+    expect(snapshotRemote(thread(), 'note').annotation).toBe('note');
+  });
+
+  it('handles an empty comments array', () => {
+    const item = snapshotRemote(thread({ comments: [] }));
+    expect(item.body).toBe('');
+    expect(item.author).toBe('unknown');
+    expect(item.replies).toEqual([]);
+  });
+});
+
+describe('snapshotLocal', () => {
+  it('copies body/severity/file/line', () => {
+    const item = snapshotLocal(draft());
+    expect(item).toMatchObject({
+      kind: 'local',
+      id: 'd1',
+      file: 'b.ts',
+      line: 5,
+      body: 'draft body',
+      severity: 'major',
+    });
+  });
+
+  it('does not mutate when the source draft changes afterwards', () => {
+    const d = draft();
+    const item = snapshotLocal(d);
+    d.body = 'CHANGED';
+    expect(item.body).toBe('draft body');
+  });
+});

--- a/apps/cli/src/plan/plan-types.ts
+++ b/apps/cli/src/plan/plan-types.ts
@@ -1,0 +1,83 @@
+import type { CommentSeverity, ReviewComment } from '@kirby/review-comments';
+import type { RemoteCommentThread } from '@kirby/vcs-core';
+
+// ── Plan items ───────────────────────────────────────────────────
+//
+// A plan item is a *value snapshot* of a comment taken at add-time.
+// We deliberately copy body/author/replies/severity/file/line by
+// value rather than holding a reference to the live comment: later
+// edits, deletes, resolves, or posts to the underlying comment must
+// not mutate what the user queued for the agent. Identity for
+// toggle/dedupe is `kind + id`.
+
+export interface PlanItemBase {
+  /** Repo-relative path, or null for a general (non-file) PR comment. */
+  file: string | null;
+  /** 1-based line (lineStart snapshot), or null for general comments. */
+  line: number | null;
+  /** Root/comment body at add-time. */
+  body: string;
+  /** Optional "Your note:" describing the approach the user wants. */
+  annotation?: string;
+}
+
+export interface RemotePlanItem extends PlanItemBase {
+  kind: 'remote';
+  /** RemoteCommentThread.id */
+  id: string;
+  /** comments[0].author */
+  author: string;
+  /** comments.slice(1) snapshot (author + body only). */
+  replies: { author: string; body: string }[];
+}
+
+export interface LocalPlanItem extends PlanItemBase {
+  kind: 'local';
+  /** ReviewComment.id */
+  id: string;
+  severity: CommentSeverity;
+}
+
+export type PlanItem = RemotePlanItem | LocalPlanItem;
+
+/** Stable identity for toggle/dedupe/membership: `${kind}:${id}`. */
+export function planItemKey(kind: PlanItem['kind'], id: string): string {
+  return `${kind}:${id}`;
+}
+
+/** Value snapshot of a remote comment thread. */
+export function snapshotRemote(
+  thread: RemoteCommentThread,
+  annotation?: string
+): RemotePlanItem {
+  const root = thread.comments[0];
+  return {
+    kind: 'remote',
+    id: thread.id,
+    file: thread.file,
+    line: thread.lineStart,
+    body: root?.body ?? '',
+    author: root?.author ?? 'unknown',
+    replies: thread.comments.slice(1).map((r) => ({
+      author: r.author,
+      body: r.body,
+    })),
+    ...(annotation ? { annotation } : {}),
+  };
+}
+
+/** Value snapshot of a local draft comment. */
+export function snapshotLocal(
+  comment: ReviewComment,
+  annotation?: string
+): LocalPlanItem {
+  return {
+    kind: 'local',
+    id: comment.id,
+    file: comment.file,
+    line: comment.lineStart,
+    body: comment.body,
+    severity: comment.severity,
+    ...(annotation ? { annotation } : {}),
+  };
+}

--- a/apps/cli/src/plan/prompt-composer.spec.ts
+++ b/apps/cli/src/plan/prompt-composer.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import type { LocalPlanItem, RemotePlanItem } from './plan-types.js';
+import { composePlanPrompt } from './prompt-composer.js';
+
+const remote: RemotePlanItem = {
+  kind: 'remote',
+  id: 't1',
+  file: 'apps/cli/src/DiffViewer.tsx',
+  line: 42,
+  body: 'This loop re-renders on every keystroke; memoize it.',
+  author: 'alice',
+  replies: [{ author: 'bob', body: 'agreed, useMemo would fix it' }],
+  annotation: 'Wrap in useMemo keyed on annotatedLines.',
+};
+
+const local: LocalPlanItem = {
+  kind: 'local',
+  id: 'd1',
+  file: 'libs/review-comments/src/types.ts',
+  line: 10,
+  body: 'severity should be an enum, not a string union.',
+  severity: 'minor',
+};
+
+describe('composePlanPrompt', () => {
+  it('renders the rich format for a mixed plan', () => {
+    expect(composePlanPrompt([remote, local])).toBe(
+      [
+        'Resolve these PR review comments:',
+        '',
+        '### 1. apps/cli/src/DiffViewer.tsx:42',
+        '@alice: This loop re-renders on every keystroke; memoize it.',
+        '  ↳ @bob: agreed, useMemo would fix it',
+        'Your note: Wrap in useMemo keyed on annotatedLines.',
+        '',
+        '### 2. libs/review-comments/src/types.ts:10  [minor]',
+        'severity should be an enum, not a string union.',
+      ].join('\n')
+    );
+  });
+
+  it('omits the note line when unannotated', () => {
+    const out = composePlanPrompt([{ ...remote, annotation: undefined }]);
+    expect(out).not.toContain('Your note:');
+  });
+
+  it('renders no reply lines when there are none', () => {
+    const out = composePlanPrompt([{ ...remote, replies: [], annotation: undefined }]);
+    expect(out).not.toContain('↳');
+  });
+
+  it('handles null file/line as a general reference', () => {
+    const out = composePlanPrompt([
+      { ...remote, file: null, line: null, replies: [], annotation: undefined },
+    ]);
+    expect(out).toContain('### 1. general');
+    expect(out).not.toContain('general:');
+  });
+});

--- a/apps/cli/src/plan/prompt-composer.ts
+++ b/apps/cli/src/plan/prompt-composer.ts
@@ -1,0 +1,55 @@
+import type { PlanItem } from './plan-types.js';
+
+// ── Prompt composer ──────────────────────────────────────────────
+//
+// Turns a plan (list of comment snapshots) into the rich prompt that
+// is forwarded to the agent. Pure — no I/O, no React — so it's
+// trivially unit-testable against exact strings.
+//
+// Format:
+//
+//   Resolve these PR review comments:
+//
+//   ### 1. apps/cli/src/DiffViewer.tsx:42  [major]
+//   @alice: This loop re-renders on every keystroke; memoize it.
+//     ↳ @bob: agreed, useMemo would fix it
+//   Your note: Wrap in useMemo keyed on annotatedLines.
+//
+// Local items carry a `[severity]` tag; remote items render the root
+// author + threaded replies. The "Your note:" line appears only when
+// the item is annotated.
+
+const HEADER = 'Resolve these PR review comments:';
+
+function locationLabel(item: PlanItem): string {
+  const file = item.file ?? 'general';
+  return item.line != null ? `${file}:${item.line}` : file;
+}
+
+function renderItem(item: PlanItem, index: number): string {
+  const lines: string[] = [];
+  const n = index + 1;
+
+  if (item.kind === 'local') {
+    lines.push(`### ${n}. ${locationLabel(item)}  [${item.severity}]`);
+    lines.push(item.body);
+  } else {
+    lines.push(`### ${n}. ${locationLabel(item)}`);
+    lines.push(`@${item.author}: ${item.body}`);
+    for (const reply of item.replies) {
+      lines.push(`  ↳ @${reply.author}: ${reply.body}`);
+    }
+  }
+
+  if (item.annotation) {
+    lines.push(`Your note: ${item.annotation}`);
+  }
+
+  return lines.join('\n');
+}
+
+/** Compose the agent prompt from a plan. */
+export function composePlanPrompt(items: PlanItem[]): string {
+  const blocks = items.map(renderItem);
+  return [HEADER, '', blocks.join('\n\n')].join('\n');
+}

--- a/apps/cli/src/pty-registry.ts
+++ b/apps/cli/src/pty-registry.ts
@@ -30,7 +30,8 @@ export function spawnSession(
   args: string[],
   cols: number,
   rows: number,
-  cwd: string
+  cwd: string,
+  env?: Record<string, string | undefined>
 ): PtyEntry {
   // Kill existing session with same name if any
   const existing = registry.get(name);
@@ -42,7 +43,15 @@ export function spawnSession(
     registry.delete(name);
   }
 
-  const pty = new PtySession(cmd, args, { cols, rows, cwd });
+  const pty = new PtySession(cmd, args, {
+    cols,
+    rows,
+    cwd,
+    // Merge over the current environment — never replace it, or the
+    // child loses PATH/HOME/etc. `env` carries only seed additions
+    // (e.g. KIRBY_SEED_PROMPT for the `continue || seed` path).
+    env: env ? { ...process.env, ...env } : undefined,
+  });
   const emu = new TerminalEmulator(cols, rows);
   const entry: PtyEntry = { pty, emu, exited: false };
 

--- a/apps/cli/src/screens/main/DiffFileListContainer.tsx
+++ b/apps/cli/src/screens/main/DiffFileListContainer.tsx
@@ -1,10 +1,13 @@
 import { useMemo } from 'react';
 import { useInput } from 'ink';
+import type { PullRequestInfo } from '@kirby/vcs-core';
 import { partitionFiles } from '@kirby/diff';
 import { DiffFileList } from '../reviews/DiffFileList.js';
 import { useKeybindResolve } from '../../context/KeybindContext.js';
 import { useConfig } from '../../context/ConfigContext.js';
 import { useSessionActions } from '../../context/SessionContext.js';
+import { usePlan } from '../../context/PlanContext.js';
+import { planItemKey } from '../../plan/plan-types.js';
 import { planCommentFooter } from '../../components/CommentThread.js';
 import type { TerminalLayout } from '../../context/LayoutContext.js';
 import type { PaneModeValue } from '../../hooks/usePaneReducer.js';
@@ -14,6 +17,7 @@ import { handleDiffFileListInput } from './main-input.js';
 interface DiffFileListContainerProps {
   pane: PaneModeValue;
   terminal: TerminalLayout;
+  selectedPr: PullRequestInfo | undefined;
   terminalFocused: boolean;
   diffBundle: DiffBundle;
 }
@@ -25,13 +29,27 @@ interface DiffFileListContainerProps {
 export function DiffFileListContainer({
   pane,
   terminal,
+  selectedPr,
   terminalFocused,
   diffBundle,
 }: DiffFileListContainerProps) {
   const keybinds = useKeybindResolve();
   const sessions = useSessionActions();
+  const plan = usePlan();
   const { config } = useConfig();
   const treeMode = config.diffFileListTree === true;
+
+  const prId = selectedPr?.id;
+  const inPlanKeys = useMemo(() => {
+    const m = new Map<string, boolean>();
+    if (prId != null) {
+      for (const i of plan.list(prId)) {
+        m.set(planItemKey(i.kind, i.id), !!i.annotation);
+      }
+    }
+    return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- plan.snapshot drives freshness
+  }, [prId, plan.snapshot]);
 
   // In tree mode, sort files alphabetically by path so siblings group
   // under the same dir. Hoisted here so the ordering is shared with
@@ -89,6 +107,8 @@ export function DiffFileListContainer({
           replyToThread: diffBundle.remote.replyToThread,
           toggleResolved: diffBundle.remote.toggleResolved,
         },
+        plan,
+        prId,
       });
     },
     { isActive: !terminalFocused }
@@ -109,6 +129,9 @@ export function DiffFileListContainer({
       selectedCommentIndex={selectedCommentIndex}
       replyingToThreadId={pane.replyingToThreadId}
       replyBuffer={pane.replyBuffer}
+      inPlanKeys={inPlanKeys}
+      annotatingPlanKey={pane.annotatingPlanKey}
+      annotationBuffer={pane.annotationBuffer}
     />
   );
 }

--- a/apps/cli/src/screens/main/DiffFileViewerContainer.tsx
+++ b/apps/cli/src/screens/main/DiffFileViewerContainer.tsx
@@ -13,6 +13,8 @@ import { useSessionActions } from '../../context/SessionContext.js';
 import { useConfig } from '../../context/ConfigContext.js';
 import { useKeybindResolve } from '../../context/KeybindContext.js';
 import { useAsyncOps } from '../../context/AsyncOpsContext.js';
+import { usePlan } from '../../context/PlanContext.js';
+import { planItemKey } from '../../plan/plan-types.js';
 import type { TerminalLayout } from '../../context/LayoutContext.js';
 import type { PaneModeValue } from '../../hooks/usePaneReducer.js';
 import type { DiffBundle } from '../../hooks/useDiffBundle.js';
@@ -53,6 +55,22 @@ export function DiffFileViewerContainer({
   const configCtx = useConfig();
   const keybinds = useKeybindResolve();
   const asyncOps = useAsyncOps();
+  const plan = usePlan();
+
+  // Set of `${kind}:${id}` keys for comments already in this PR's plan.
+  // Recomputed on any plan change (plan.snapshot identity) and threaded
+  // to the cards as booleans so their memoization stays stable.
+  const prId = selectedPr?.id;
+  const inPlanKeys = useMemo(() => {
+    const m = new Map<string, boolean>();
+    if (prId != null) {
+      for (const i of plan.list(prId)) {
+        m.set(planItemKey(i.kind, i.id), !!i.annotation);
+      }
+    }
+    return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- plan.snapshot drives freshness
+  }, [prId, plan.snapshot]);
 
   // Trigger a per-file diff fetch on file open. Cached internally
   // by useDiffData, so navigating back and forth is free.
@@ -210,6 +228,7 @@ export function DiffFileViewerContainer({
         sessions: sessionCtx,
         asyncOps,
         keybinds,
+        plan,
       });
     },
     { isActive: !terminalFocused }
@@ -233,6 +252,9 @@ export function DiffFileViewerContainer({
       editBuffer={pane.editBuffer}
       replyingToThreadId={pane.replyingToThreadId}
       replyBuffer={pane.replyBuffer}
+      inPlanKeys={inPlanKeys}
+      annotatingPlanKey={pane.annotatingPlanKey}
+      annotationBuffer={pane.annotationBuffer}
     />
   );
 }

--- a/apps/cli/src/screens/main/MainContent.tsx
+++ b/apps/cli/src/screens/main/MainContent.tsx
@@ -8,6 +8,7 @@ import { TerminalPane } from './TerminalPane.js';
 import { DiffFileListContainer } from './DiffFileListContainer.js';
 import { DiffFileViewerContainer } from './DiffFileViewerContainer.js';
 import { GeneralCommentsContainer } from './GeneralCommentsContainer.js';
+import { PlanCheckoutContainer } from './PlanCheckoutContainer.js';
 import type { TerminalLayout } from '../../context/LayoutContext.js';
 import type { PaneModeValue } from '../../hooks/usePaneReducer.js';
 import { useDiffBundle } from '../../hooks/useDiffBundle.js';
@@ -34,7 +35,8 @@ type ScreenType =
   | 'prDetail'
   | 'diff'
   | 'diffFile'
-  | 'comments';
+  | 'comments'
+  | 'planCheckout';
 
 // Pure router for the main content pane. Renders exactly one of the
 // mutually-exclusive sub-panes based on modal and pane-mode state, in
@@ -79,6 +81,7 @@ export function MainContent({
     if (pane.paneMode === 'diff') return 'diff';
     if (pane.paneMode === 'diff-file') return 'diffFile';
     if (pane.paneMode === 'comments') return 'comments';
+    if (pane.paneMode === 'plan-checkout') return 'planCheckout';
     return 'terminal';
   })();
 
@@ -155,6 +158,15 @@ export function MainContent({
           terminal={terminal}
           terminalFocused={terminalFocused}
           diffBundle={diffBundle}
+        />
+      );
+    case 'planCheckout':
+      return (
+        <PlanCheckoutContainer
+          pane={pane}
+          terminal={terminal}
+          selectedPr={selectedPr}
+          terminalFocused={terminalFocused}
         />
       );
   }

--- a/apps/cli/src/screens/main/MainContent.tsx
+++ b/apps/cli/src/screens/main/MainContent.tsx
@@ -133,6 +133,7 @@ export function MainContent({
         <DiffFileListContainer
           pane={pane}
           terminal={terminal}
+          selectedPr={selectedPr}
           terminalFocused={terminalFocused}
           diffBundle={diffBundle}
         />

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -145,7 +145,8 @@ function MainTabBody({
     if (
       pane.paneMode === 'diff' ||
       pane.paneMode === 'diff-file' ||
-      pane.paneMode === 'comments'
+      pane.paneMode === 'comments' ||
+      pane.paneMode === 'plan-checkout'
     )
       return;
 

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -214,6 +214,7 @@ function MainTabBody({
         paneRows: terminal.paneRows,
       }
     : terminal;
+  const showPlanIndicator = pane.paneMode !== 'plan-checkout';
 
   useInactiveAlertWatcher(sidebar.sessionNameForTerminal);
 
@@ -251,7 +252,7 @@ function MainTabBody({
           onFocusSidebar={onTerminalEscape}
         />
       </Pane>
-      <TopRightOverlay hidePlanIndicator={pane.paneMode === 'plan-checkout'} />
+      <TopRightOverlay showPlanIndicator={showPlanIndicator} />
     </>
   );
 }

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -19,6 +19,7 @@ import { useSessionActions } from '../../context/SessionContext.js';
 import { useConfig } from '../../context/ConfigContext.js';
 import { useKeybinds } from '../../context/KeybindContext.js';
 import { useSidebar } from '../../context/SidebarContext.js';
+import { TopRightOverlay } from '../../components/TopRightOverlay.js';
 import { usePaneReducer } from '../../hooks/usePaneReducer.js';
 import { getItemKey } from '../../types.js';
 import { handleConfirmInput, handleSidebarInput } from './main-input.js';
@@ -250,6 +251,7 @@ function MainTabBody({
           onFocusSidebar={onTerminalEscape}
         />
       </Pane>
+      <TopRightOverlay hidePlanIndicator={pane.paneMode === 'plan-checkout'} />
     </>
   );
 }

--- a/apps/cli/src/screens/main/MainTab.tsx
+++ b/apps/cli/src/screens/main/MainTab.tsx
@@ -191,6 +191,7 @@ function MainTabBody({
     settingsOpen: settings.settingsOpen,
     controlsOpen: settings.controlsOpen,
     reviewConfirmActive: pane.reviewConfirm !== null,
+    agentId: configCtx.config.agentId,
     aiCommand: configCtx.config.aiCommand,
     prTitle: sidebar.selectedPr?.title,
     sessionName: sidebar.sessionNameForTerminal,

--- a/apps/cli/src/screens/main/PlanCheckoutContainer.tsx
+++ b/apps/cli/src/screens/main/PlanCheckoutContainer.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+import { useInput } from 'ink';
+import type { PullRequestInfo } from '@kirby/vcs-core';
+import { PlanCheckoutPane } from '../reviews/PlanCheckoutPane.js';
+import { useKeybindResolve } from '../../context/KeybindContext.js';
+import { useSessionActions } from '../../context/SessionContext.js';
+import { useSidebar } from '../../context/SidebarContext.js';
+import { useNavState, useNavActions } from '../../context/NavContext.js';
+import { useAsyncOps } from '../../context/AsyncOpsContext.js';
+import { usePlan } from '../../context/PlanContext.js';
+import type { TerminalLayout } from '../../context/LayoutContext.js';
+import type { PaneModeValue } from '../../hooks/usePaneReducer.js';
+import { handlePlanCheckoutInput } from './main-input.js';
+
+interface PlanCheckoutContainerProps {
+  pane: PaneModeValue;
+  terminal: TerminalLayout;
+  selectedPr: PullRequestInfo | undefined;
+  terminalFocused: boolean;
+}
+
+// Interactive checkout pane: review the per-PR plan as a checklist,
+// prune items, edit notes, then forward the composed prompt to a Claude
+// agent in the PR's worktree. Mounted by MainContent when
+// paneMode === 'plan-checkout'.
+export function PlanCheckoutContainer({
+  pane,
+  terminal,
+  selectedPr,
+  terminalFocused,
+}: PlanCheckoutContainerProps) {
+  const keybinds = useKeybindResolve();
+  const sessions = useSessionActions();
+  const sidebar = useSidebar();
+  const navState = useNavState();
+  const navActions = useNavActions();
+  const nav = useMemo(
+    () => ({ ...navState, ...navActions }),
+    [navState, navActions]
+  );
+  const asyncOps = useAsyncOps();
+  const plan = usePlan();
+
+  const prId = selectedPr?.id;
+  const items = prId != null ? plan.list(prId) : [];
+
+  useInput(
+    (input, key) => {
+      handlePlanCheckoutInput(input, key, {
+        pane,
+        plan,
+        selectedPr,
+        terminal,
+        asyncOps,
+        sessions,
+        sidebar,
+        nav,
+        keybinds,
+      });
+    },
+    { isActive: !terminalFocused }
+  );
+
+  return (
+    <PlanCheckoutPane
+      items={items}
+      selectedIndex={pane.planCheckoutIndex}
+      paneCols={terminal.paneCols}
+      annotatingPlanKey={pane.annotatingPlanKey}
+      annotationBuffer={pane.annotationBuffer}
+      target={pane.planCheckoutTarget}
+    />
+  );
+}

--- a/apps/cli/src/screens/main/PlanCheckoutContainer.tsx
+++ b/apps/cli/src/screens/main/PlanCheckoutContainer.tsx
@@ -8,6 +8,7 @@ import { useSidebar } from '../../context/SidebarContext.js';
 import { useNavState, useNavActions } from '../../context/NavContext.js';
 import { useAsyncOps } from '../../context/AsyncOpsContext.js';
 import { usePlan } from '../../context/PlanContext.js';
+import { useConfig } from '../../context/ConfigContext.js';
 import type { TerminalLayout } from '../../context/LayoutContext.js';
 import type { PaneModeValue } from '../../hooks/usePaneReducer.js';
 import { handlePlanCheckoutInput } from './main-input.js';
@@ -40,6 +41,7 @@ export function PlanCheckoutContainer({
   );
   const asyncOps = useAsyncOps();
   const plan = usePlan();
+  const config = useConfig();
 
   const prId = selectedPr?.id;
   const items = prId != null ? plan.list(prId) : [];
@@ -56,6 +58,7 @@ export function PlanCheckoutContainer({
         sidebar,
         nav,
         keybinds,
+        config,
       });
     },
     { isActive: !terminalFocused }

--- a/apps/cli/src/screens/main/branch-picker-input.ts
+++ b/apps/cli/src/screens/main/branch-picker-input.ts
@@ -6,11 +6,9 @@ import {
   fetchRemote,
   branchToSessionName,
 } from '@kirby/worktree-manager';
-import { spawnSession } from '../../pty-registry.js';
+import { launchSession } from '../../session/launch-session.js';
 import { handleTextInput } from '../../utils/handle-text-input.js';
 import type { BranchPickerHandlerCtx } from './input-types.js';
-
-const DEFAULT_AI_COMMAND = 'claude --continue || claude';
 
 export function startAiSession(
   name: string,
@@ -19,8 +17,17 @@ export function startAiSession(
   cwd: string,
   config: AppConfig
 ) {
-  const cmd = config.aiCommand || DEFAULT_AI_COMMAND;
-  spawnSession(name, '/bin/sh', ['-c', cmd], cols, rows, cwd);
+  // Resume a prior conversation in this worktree if there is one, else
+  // start blank. The configured agent decides whether continue is even
+  // possible (only Claude, currently) — everyone else starts blank.
+  launchSession({
+    name,
+    cwd,
+    cols,
+    rows,
+    config,
+    request: { intent: 'continue-or-blank' },
+  });
 }
 
 export function handleBranchPickerInput(

--- a/apps/cli/src/screens/main/confirm-input.ts
+++ b/apps/cli/src/screens/main/confirm-input.ts
@@ -1,6 +1,7 @@
 import type { Key } from 'ink';
 import { createWorktree } from '@kirby/worktree-manager';
-import { spawnSession, hasSession } from '../../pty-registry.js';
+import { hasSession } from '../../pty-registry.js';
+import { launchSession } from '../../session/launch-session.js';
 import { getPrFromItem } from '../../types.js';
 import { handleTextInput } from '../../utils/handle-text-input.js';
 import type { ConfirmHandlerCtx } from './input-types.js';
@@ -14,10 +15,9 @@ async function startReviewSession(
   const pr = getPrFromItem(ctx.selectedItem);
   if (!pr) return;
 
-  let prompt =
-    `Review PR #${pr.id} ("${pr.title || pr.sourceBranch}") ` +
-    `merging ${pr.sourceBranch} → ${pr.targetBranch} ` +
-    `by ${pr.createdByDisplayName || 'unknown'}.\n\n` +
+  // Reusable how-to guidance (installed as a system prompt for agents
+  // that support it, e.g. Claude; folded into the prompt otherwise).
+  const guidance =
     `To add review comments, use this command:\n` +
     `  kirby util add-comment --pr=${pr.id} --file=<path> --lineStart=<n> --lineEnd=<n> --severity=<critical|major|minor|nit> --body="<comment>"\n\n` +
     `Rules:\n` +
@@ -25,11 +25,17 @@ async function startReviewSession(
     `- lineStart/lineEnd are 1-based line numbers in the NEW version of the file\n` +
     `- Use --side=LEFT only when commenting on removed/deleted lines\n` +
     `- Severity: critical (blocks merge), major (should fix), minor (nice to fix), nit (style/preference)\n` +
-    `- Comments appear live in the reviewer's diff viewer\n\n` +
+    `- Comments appear live in the reviewer's diff viewer`;
+
+  // The per-PR task prompt.
+  let task =
+    `Review PR #${pr.id} ("${pr.title || pr.sourceBranch}") ` +
+    `merging ${pr.sourceBranch} → ${pr.targetBranch} ` +
+    `by ${pr.createdByDisplayName || 'unknown'}.\n\n` +
     `Review all changed files thoroughly. Add comments for any issues found.`;
 
   if (additionalInstruction) {
-    prompt +=
+    task +=
       ` ADDITIONAL USER INSTRUCTION (overrides previous where applicable): ` +
       additionalInstruction;
   }
@@ -42,17 +48,22 @@ async function startReviewSession(
     return;
   }
 
-  const safePrompt = prompt.replace(/['"]/g, '');
-  const command = `claude --continue || claude '${safePrompt}'`;
-
-  spawnSession(
-    ctx.sessionNameForTerminal,
-    '/bin/sh',
-    ['-c', command],
-    ctx.terminal.paneCols,
-    ctx.terminal.paneRows,
-    worktreePath
-  );
+  // Resume an existing review conversation in this worktree if one
+  // exists, otherwise seed a fresh session with the review prompt. The
+  // prompt is delivered as argv/env by the launcher — never composed
+  // into a shell string — so quotes in the PR title survive intact.
+  launchSession({
+    name: ctx.sessionNameForTerminal,
+    cwd: worktreePath,
+    cols: ctx.terminal.paneCols,
+    rows: ctx.terminal.paneRows,
+    config: ctx.config.config,
+    request: {
+      intent: 'continue-or-seed',
+      prompt: task,
+      systemGuidance: guidance,
+    },
+  });
 }
 
 const CONFIRM_OPTIONS = 4;

--- a/apps/cli/src/screens/main/diff-file-list-input.ts
+++ b/apps/cli/src/screens/main/diff-file-list-input.ts
@@ -1,6 +1,8 @@
 import type { Key } from 'ink';
 import { getDisplayFiles } from '@kirby/diff';
 import { handleReplyModeInput } from '../../utils/reply-mode.js';
+import { handlePlanAnnotateInput } from '../../utils/plan-annotate-mode.js';
+import { planItemKey, snapshotRemote } from '../../plan/plan-types.js';
 import type { DiffFileListHandlerCtx } from './input-types.js';
 
 // Comment-nav semantics mirror the diff viewer's merged nav pool: cycle
@@ -29,6 +31,17 @@ export function handleDiffFileListInput(
       pane: ctx.pane,
       flashStatus: ctx.sessions.flashStatus,
       replyToThread: ctx.remoteCtx.replyToThread,
+    })
+  ) {
+    return;
+  }
+
+  // Plan annotation mode bypass — same contract as reply mode.
+  if (
+    handlePlanAnnotateInput(input, key, {
+      pane: ctx.pane,
+      plan: ctx.plan,
+      prId: ctx.prId,
     })
   ) {
     return;
@@ -131,6 +144,37 @@ export function handleDiffFileListInput(
         const msg = err instanceof Error ? err.message : String(err);
         ctx.sessions.flashStatus(`Failed: ${msg}`);
       });
+    return;
+  }
+
+  // ── Plan ("add-to-cart") actions on the selected comment ────────
+  if (action === 'diff-file-list.plan-toggle') {
+    if (selectedCommentIdx < 0 || ctx.prId == null) return;
+    const thread = ctx.shownGeneralComments[selectedCommentIdx];
+    if (!thread) return;
+    const added = ctx.plan.toggle(ctx.prId, snapshotRemote(thread));
+    ctx.sessions.flashStatus(added ? 'Added to plan' : 'Removed from plan');
+    return;
+  }
+  if (action === 'diff-file-list.plan-annotate') {
+    if (selectedCommentIdx < 0 || ctx.prId == null) return;
+    const thread = ctx.shownGeneralComments[selectedCommentIdx];
+    if (!thread) return;
+    const item = snapshotRemote(thread);
+    ctx.plan.add(ctx.prId, item);
+    ctx.pane.setAnnotatingPlanKey(planItemKey(item.kind, item.id));
+    ctx.pane.setAnnotationBuffer(item.annotation ?? '');
+    return;
+  }
+  if (action === 'diff-file-list.plan-checkout') {
+    if (ctx.prId == null || ctx.plan.count(ctx.prId) === 0) {
+      ctx.sessions.flashStatus('Plan is empty');
+      return;
+    }
+    ctx.pane.setPriorPaneMode('diff');
+    ctx.pane.setPlanCheckoutIndex(0);
+    ctx.pane.setPlanCheckoutTarget(null);
+    ctx.pane.setPaneMode('plan-checkout');
     return;
   }
 

--- a/apps/cli/src/screens/main/diff-file-list-input.ts
+++ b/apps/cli/src/screens/main/diff-file-list-input.ts
@@ -161,9 +161,13 @@ export function handleDiffFileListInput(
     const thread = ctx.shownGeneralComments[selectedCommentIdx];
     if (!thread) return;
     const item = snapshotRemote(thread);
+    const key = planItemKey(item.kind, item.id);
+    const existing = ctx.plan
+      .list(ctx.prId)
+      .find((i) => planItemKey(i.kind, i.id) === key)?.annotation;
     ctx.plan.add(ctx.prId, item);
-    ctx.pane.setAnnotatingPlanKey(planItemKey(item.kind, item.id));
-    ctx.pane.setAnnotationBuffer(item.annotation ?? '');
+    ctx.pane.setAnnotatingPlanKey(key);
+    ctx.pane.setAnnotationBuffer(existing ?? '');
     return;
   }
   if (action === 'diff-file-list.plan-checkout') {

--- a/apps/cli/src/screens/main/diff-viewer-input.ts
+++ b/apps/cli/src/screens/main/diff-viewer-input.ts
@@ -12,6 +12,9 @@ import {
   type CommentPositionInfo,
 } from '@kirby/review-comments';
 import { getDisplayFiles } from '@kirby/diff';
+import { handlePlanAnnotateInput } from '../../utils/plan-annotate-mode.js';
+import { planItemKey, snapshotLocal, snapshotRemote } from '../../plan/plan-types.js';
+import type { PlanItem } from '../../plan/plan-types.js';
 import type { DiffViewerHandlerCtx } from './input-types.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -156,6 +159,17 @@ export function handleDiffViewerInput(
       ctx.pane.setPendingDeleteCommentId(null);
       return;
     }
+    return;
+  }
+
+  // ── Plan annotation mode (exempt from keybind resolution) ──
+  if (
+    handlePlanAnnotateInput(input, key, {
+      pane: ctx.pane,
+      plan: ctx.plan,
+      prId: ctx.commentCtx?.prId,
+    })
+  ) {
     return;
   }
 
@@ -451,6 +465,42 @@ export function handleDiffViewerInput(
         const msg = err instanceof Error ? err.message : String(err);
         ctx.sessions.flashStatus(`Failed: ${msg}`);
       });
+    return;
+  }
+
+  // ── Plan ("add-to-cart") actions ────────────────────────────────
+  // Resolve the selected comment to a snapshot — a local draft or a
+  // remote thread. Both feed the same per-PR plan.
+  const prId = ctx.commentCtx?.prId;
+  const planTarget: PlanItem | null = selectedLocal
+    ? snapshotLocal(selectedLocal)
+    : selectedRemoteThread
+    ? snapshotRemote(selectedRemoteThread)
+    : null;
+
+  if (action === 'diff-viewer.plan-toggle' && planTarget && prId != null) {
+    const added = ctx.plan.toggle(prId, planTarget);
+    ctx.sessions.flashStatus(added ? 'Added to plan' : 'Removed from plan');
+    return;
+  }
+
+  if (action === 'diff-viewer.plan-annotate' && planTarget && prId != null) {
+    // Add immediately (cart feedback), then open the note composer.
+    ctx.plan.add(prId, planTarget);
+    ctx.pane.setAnnotatingPlanKey(planItemKey(planTarget.kind, planTarget.id));
+    ctx.pane.setAnnotationBuffer(planTarget.annotation ?? '');
+    return;
+  }
+
+  if (action === 'diff-viewer.plan-checkout') {
+    if (prId == null || ctx.plan.count(prId) === 0) {
+      ctx.sessions.flashStatus('Plan is empty');
+      return;
+    }
+    ctx.pane.setPriorPaneMode('diff-file');
+    ctx.pane.setPlanCheckoutIndex(0);
+    ctx.pane.setPlanCheckoutTarget(null);
+    ctx.pane.setPaneMode('plan-checkout');
     return;
   }
 }

--- a/apps/cli/src/screens/main/diff-viewer-input.ts
+++ b/apps/cli/src/screens/main/diff-viewer-input.ts
@@ -13,7 +13,11 @@ import {
 } from '@kirby/review-comments';
 import { getDisplayFiles } from '@kirby/diff';
 import { handlePlanAnnotateInput } from '../../utils/plan-annotate-mode.js';
-import { planItemKey, snapshotLocal, snapshotRemote } from '../../plan/plan-types.js';
+import {
+  planItemKey,
+  snapshotLocal,
+  snapshotRemote,
+} from '../../plan/plan-types.js';
 import type { PlanItem } from '../../plan/plan-types.js';
 import type { DiffViewerHandlerCtx } from './input-types.js';
 
@@ -485,10 +489,15 @@ export function handleDiffViewerInput(
   }
 
   if (action === 'diff-viewer.plan-annotate' && planTarget && prId != null) {
-    // Add immediately (cart feedback), then open the note composer.
+    // Add immediately (cart feedback), then open the note composer
+    // pre-filled with any existing note so re-annotating never blanks it.
+    const key = planItemKey(planTarget.kind, planTarget.id);
+    const existing = ctx.plan
+      .list(prId)
+      .find((i) => planItemKey(i.kind, i.id) === key)?.annotation;
     ctx.plan.add(prId, planTarget);
-    ctx.pane.setAnnotatingPlanKey(planItemKey(planTarget.kind, planTarget.id));
-    ctx.pane.setAnnotationBuffer(planTarget.annotation ?? '');
+    ctx.pane.setAnnotatingPlanKey(key);
+    ctx.pane.setAnnotationBuffer(existing ?? '');
     return;
   }
 

--- a/apps/cli/src/screens/main/focus.spec.ts
+++ b/apps/cli/src/screens/main/focus.spec.ts
@@ -22,6 +22,7 @@ const baseTitle: PaneTitleState = {
   settingsOpen: false,
   controlsOpen: false,
   reviewConfirmActive: false,
+  agentId: undefined,
   aiCommand: undefined,
   prTitle: undefined,
   sessionName: null,

--- a/apps/cli/src/screens/main/focus.ts
+++ b/apps/cli/src/screens/main/focus.ts
@@ -10,8 +10,8 @@
 //      that the sidebar is NOT focused in those cases.
 
 import type { Focus, PaneMode } from '../../types.js';
-import { resolvePresetName } from '../../utils/resolve-preset-name.js';
-import { AI_PRESETS } from '../../components/SettingsPanel.js';
+import type { AgentId, AppConfig } from '@kirby/vcs-core';
+import { resolveAgent } from '../../agents/registry.js';
 
 export interface FocusState {
   navFocus: Focus;
@@ -62,6 +62,7 @@ export interface PaneTitleState {
   settingsOpen: boolean;
   controlsOpen: boolean;
   reviewConfirmActive: boolean;
+  agentId: AgentId | undefined;
   aiCommand: string | undefined;
   prTitle: string | undefined;
   sessionName: string | null;
@@ -92,7 +93,14 @@ export function getPaneTitle(s: PaneTitleState): string {
     return 'Files Changed';
   if (s.paneMode === 'plan-checkout') return 'Plan Checkout';
 
-  const agent = resolvePresetName(s.aiCommand, AI_PRESETS, 'Agent');
+  // Resolve the display name through the agent registry so it honors an
+  // explicit agentId or a legacy aiCommand. The hidden test runner (and
+  // any unrecognized command) shows the generic "Agent".
+  const resolved = resolveAgent({
+    agentId: s.agentId,
+    aiCommand: s.aiCommand,
+  } as AppConfig);
+  const agent = resolved.hidden ? 'Agent' : resolved.name;
   const label = s.prTitle || s.sessionName;
   const base = label
     ? `\u{1F916} ${agent} \u2014 ${label}`

--- a/apps/cli/src/screens/main/focus.ts
+++ b/apps/cli/src/screens/main/focus.ts
@@ -39,7 +39,8 @@ export function getMainFocused(s: FocusState): boolean {
   if (
     s.paneMode === 'diff' ||
     s.paneMode === 'diff-file' ||
-    s.paneMode === 'comments'
+    s.paneMode === 'comments' ||
+    s.paneMode === 'plan-checkout'
   )
     return true;
   return s.navFocus === 'terminal';
@@ -89,6 +90,7 @@ export function getPaneTitle(s: PaneTitleState): string {
   if (s.paneMode === 'pr-detail') return 'Pull Request';
   if (s.paneMode === 'diff' || s.paneMode === 'diff-file')
     return 'Files Changed';
+  if (s.paneMode === 'plan-checkout') return 'Plan Checkout';
 
   const agent = resolvePresetName(s.aiCommand, AI_PRESETS, 'Agent');
   const label = s.prTitle || s.sessionName;

--- a/apps/cli/src/screens/main/input-types.ts
+++ b/apps/cli/src/screens/main/input-types.ts
@@ -23,6 +23,7 @@ import type {
 } from '../../input-handlers.js';
 import type { PaneModeValue } from '../../hooks/usePaneReducer.js';
 import type { CommentPositionInfo, RowMap } from '@kirby/review-comments';
+import type { PlanValue } from '../../context/PlanContext.js';
 
 // ── Context slice types ──────────────────────────────────────────
 
@@ -70,6 +71,10 @@ export interface DiffFileListHandlerCtx {
     toggleResolved: (threadId: string, resolved: boolean) => Promise<boolean>;
   };
   sessions: SessionActionsContextValue;
+  /** Per-PR plan store ("add-to-cart"). */
+  plan: PlanValue;
+  /** PR id for plan keying; undefined until PR data resolves. */
+  prId?: number;
 }
 
 export interface CommentContext {
@@ -112,6 +117,20 @@ export interface DiffViewerHandlerCtx {
   config: ConfigContextValue;
   sessions: SessionActionsContextValue;
   asyncOps: AsyncOpsValue;
+  keybinds: KeybindResolveValue;
+  /** Per-PR plan store ("add-to-cart"). */
+  plan: PlanValue;
+}
+
+export interface PlanCheckoutHandlerCtx {
+  pane: PaneModeValue;
+  plan: PlanValue;
+  selectedPr: PullRequestInfo | undefined;
+  terminal: TerminalLayout;
+  asyncOps: AsyncOpsValue;
+  sessions: SessionActionsContextValue;
+  sidebar: SidebarContextValue;
+  nav: NavValue;
   keybinds: KeybindResolveValue;
 }
 

--- a/apps/cli/src/screens/main/input-types.ts
+++ b/apps/cli/src/screens/main/input-types.ts
@@ -132,6 +132,7 @@ export interface PlanCheckoutHandlerCtx {
   sidebar: SidebarContextValue;
   nav: NavValue;
   keybinds: KeybindResolveValue;
+  config: ConfigContextValue;
 }
 
 export interface ConfirmHandlerCtx {

--- a/apps/cli/src/screens/main/main-input.ts
+++ b/apps/cli/src/screens/main/main-input.ts
@@ -5,6 +5,7 @@ export type {
   CommentContext,
   DiffViewerHandlerCtx,
   ConfirmHandlerCtx,
+  PlanCheckoutHandlerCtx,
   SidebarInputCtx,
 } from './input-types.js';
 export { handleBranchPickerInput } from './branch-picker-input.js';
@@ -12,4 +13,5 @@ export { handleConfirmDeleteInput } from './confirm-delete-input.js';
 export { handleDiffFileListInput } from './diff-file-list-input.js';
 export { handleDiffViewerInput } from './diff-viewer-input.js';
 export { handleConfirmInput } from './confirm-input.js';
+export { handlePlanCheckoutInput } from './plan-checkout-input.js';
 export { handleSidebarInput } from './sidebar-input.js';

--- a/apps/cli/src/screens/main/plan-checkout-input.ts
+++ b/apps/cli/src/screens/main/plan-checkout-input.ts
@@ -2,7 +2,7 @@ import type { Key } from 'ink';
 import { hasSession } from '../../pty-registry.js';
 import { branchToSessionName } from '@kirby/worktree-manager';
 import { handlePlanAnnotateInput } from '../../utils/plan-annotate-mode.js';
-import { checkoutPlan } from '../../plan/checkout-orchestrator.js';
+import { checkoutPlan } from '../../session/checkout-plan.js';
 import { composePlanPrompt } from '../../plan/prompt-composer.js';
 import { planItemKey } from '../../plan/plan-types.js';
 import type { PlanCheckoutHandlerCtx } from './input-types.js';
@@ -24,9 +24,7 @@ export function handlePlanCheckoutInput(
   const prId = selectedPr?.id;
 
   // ── 1. Annotation composer ──
-  if (
-    handlePlanAnnotateInput(input, key, { pane, plan, prId })
-  ) {
+  if (handlePlanAnnotateInput(input, key, { pane, plan, prId })) {
     return;
   }
 
@@ -134,6 +132,7 @@ function runCheckout(
       paneCols: ctx.terminal.paneCols,
       paneRows: ctx.terminal.paneRows,
       mode,
+      config: ctx.config.config,
       flashStatus: ctx.sessions.flashStatus,
     });
     if (result === 'failed') {

--- a/apps/cli/src/screens/main/plan-checkout-input.ts
+++ b/apps/cli/src/screens/main/plan-checkout-input.ts
@@ -1,0 +1,157 @@
+import type { Key } from 'ink';
+import { hasSession } from '../../pty-registry.js';
+import { branchToSessionName } from '@kirby/worktree-manager';
+import { handlePlanAnnotateInput } from '../../utils/plan-annotate-mode.js';
+import { checkoutPlan } from '../../plan/checkout-orchestrator.js';
+import { composePlanPrompt } from '../../plan/prompt-composer.js';
+import { planItemKey } from '../../plan/plan-types.js';
+import type { PlanCheckoutHandlerCtx } from './input-types.js';
+
+// Interactive checkout pane input.
+//
+// Three modes, checked in order:
+//   1. Annotation composer (annotatingPlanKey set) — edit a note.
+//   2. Target choice (planCheckoutTarget set) — inject vs new-session,
+//      shown only when an agent is already running in the worktree.
+//   3. Checklist navigation — move/toggle-include/annotate/send/back.
+
+export function handlePlanCheckoutInput(
+  input: string,
+  key: Key,
+  ctx: PlanCheckoutHandlerCtx
+): void {
+  const { pane, plan, selectedPr } = ctx;
+  const prId = selectedPr?.id;
+
+  // ── 1. Annotation composer ──
+  if (
+    handlePlanAnnotateInput(input, key, { pane, plan, prId })
+  ) {
+    return;
+  }
+
+  const items = prId != null ? plan.list(prId) : [];
+
+  // ── 2. Inject-vs-new-session choice (State A) ──
+  if (pane.planCheckoutTarget) {
+    const action = ctx.keybinds.resolve(input, key, 'plan-checkout');
+    if (action === 'plan-checkout.back') {
+      pane.setPlanCheckoutTarget(null);
+      return;
+    }
+    if (
+      action === 'plan-checkout.navigate-up' ||
+      action === 'plan-checkout.navigate-down'
+    ) {
+      pane.setPlanCheckoutTarget(
+        pane.planCheckoutTarget === 'inject' ? 'new-session' : 'inject'
+      );
+      return;
+    }
+    if (action === 'plan-checkout.send') {
+      runCheckout(ctx, pane.planCheckoutTarget);
+      return;
+    }
+    return;
+  }
+
+  // ── 3. Checklist navigation ──
+  const action = ctx.keybinds.resolve(input, key, 'plan-checkout');
+
+  if (action === 'plan-checkout.back') {
+    pane.setPaneMode(pane.priorPaneMode);
+    return;
+  }
+
+  if (action === 'plan-checkout.navigate-down') {
+    pane.setPlanCheckoutIndex((i) => Math.min(i + 1, items.length - 1));
+    return;
+  }
+  if (action === 'plan-checkout.navigate-up') {
+    pane.setPlanCheckoutIndex((i) => Math.max(i - 1, 0));
+    return;
+  }
+
+  const selected = items[pane.planCheckoutIndex];
+
+  // Toggle-include here means "drop from the plan" — the plan IS the
+  // cart, so excluding an item removes it. Keeps the top-right
+  // indicator truthful.
+  if (action === 'plan-checkout.toggle-include' && selected && prId != null) {
+    plan.remove(prId, selected.kind, selected.id);
+    const remaining = plan.count(prId);
+    if (remaining === 0) {
+      // Nothing left — bail back to where we came from.
+      pane.setPaneMode(pane.priorPaneMode);
+      return;
+    }
+    pane.setPlanCheckoutIndex((i) => Math.min(i, remaining - 1));
+    return;
+  }
+
+  if (action === 'plan-checkout.annotate' && selected) {
+    pane.setAnnotatingPlanKey(planItemKey(selected.kind, selected.id));
+    pane.setAnnotationBuffer(selected.annotation ?? '');
+    return;
+  }
+
+  if (action === 'plan-checkout.send') {
+    if (!selectedPr || prId == null || items.length === 0) {
+      ctx.sessions.flashStatus('Plan is empty');
+      return;
+    }
+    const name = branchToSessionName(selectedPr.sourceBranch);
+    if (hasSession(name)) {
+      // An agent is running — ask how to deliver. Default to inject
+      // (non-destructive).
+      pane.setPlanCheckoutTarget('inject');
+      return;
+    }
+    // No running agent — spawn straight away (states B/C).
+    runCheckout(ctx, 'new-session');
+    return;
+  }
+}
+
+function runCheckout(
+  ctx: PlanCheckoutHandlerCtx,
+  mode: 'inject' | 'new-session'
+): void {
+  const { pane, plan, selectedPr } = ctx;
+  if (!selectedPr) return;
+  const prId = selectedPr.id;
+  const items = plan.list(prId);
+  if (items.length === 0) {
+    ctx.sessions.flashStatus('Plan is empty');
+    return;
+  }
+  const prompt = composePlanPrompt(items);
+
+  ctx.asyncOps.run('start-session', async () => {
+    const result = await checkoutPlan({
+      pr: selectedPr,
+      prompt,
+      paneCols: ctx.terminal.paneCols,
+      paneRows: ctx.terminal.paneRows,
+      mode,
+      flashStatus: ctx.sessions.flashStatus,
+    });
+    if (result === 'failed') {
+      // Leave the plan intact so the user can retry.
+      pane.setPlanCheckoutTarget(null);
+      return;
+    }
+
+    plan.clear(prId);
+    await ctx.sessions.refreshSessions();
+    const name = branchToSessionName(selectedPr.sourceBranch);
+    ctx.sidebar.selectByKey(`session:${name}`);
+    ctx.sessions.flashStatus(
+      result === 'injected' ? 'Plan sent to agent' : 'Agent started with plan'
+    );
+    pane.setPlanCheckoutTarget(null);
+    pane.setPaneMode('terminal');
+    ctx.nav.setFocus('terminal');
+    ctx.pane.setReconnectKey((k) => k + 1);
+  });
+}

--- a/apps/cli/src/screens/main/plan-input.spec.ts
+++ b/apps/cli/src/screens/main/plan-input.spec.ts
@@ -23,7 +23,17 @@ import {
 } from '../../plan/plan-store.js';
 
 const PR_ID = 1;
-const plan = { snapshot: new Map(), add, remove, has, toggle, annotate, list, count, clear };
+const plan = {
+  snapshot: new Map(),
+  add,
+  remove,
+  has,
+  toggle,
+  annotate,
+  list,
+  count,
+  clear,
+};
 
 function makeKey(overrides: Partial<Key> = {}): Key {
   return {
@@ -52,8 +62,11 @@ function makeKey(overrides: Partial<Key> = {}): Key {
 }
 
 const keybinds = {
-  resolve: (input: string, key: Key, context: 'diff-viewer' | 'diff-file-list') =>
-    resolveAction(input, key, context, NORMIE_PRESET.bindings, ACTIONS),
+  resolve: (
+    input: string,
+    key: Key,
+    context: 'diff-viewer' | 'diff-file-list'
+  ) => resolveAction(input, key, context, NORMIE_PRESET.bindings, ACTIONS),
 } as unknown as DiffViewerHandlerCtx['keybinds'];
 
 function localDraft(id = 'd1'): ReviewComment {
@@ -81,7 +94,12 @@ function remoteThread(id = 't1'): RemoteCommentThread {
     isOutdated: false,
     canResolve: true,
     comments: [
-      { id: `${id}-root`, author: 'alice', body: 'root', createdAt: '2026-01-01' },
+      {
+        id: `${id}-root`,
+        author: 'alice',
+        body: 'root',
+        createdAt: '2026-01-01',
+      },
     ],
   };
 }
@@ -110,7 +128,10 @@ function makePane(initial: Record<string, unknown> = {}) {
       if (prop.startsWith('set')) {
         const field = prop[3]!.toLowerCase() + prop.slice(4);
         return (v: unknown) => {
-          t[field] = typeof v === 'function' ? (v as (p: unknown) => unknown)(t[field]) : v;
+          t[field] =
+            typeof v === 'function'
+              ? (v as (p: unknown) => unknown)(t[field])
+              : v;
         };
       }
       return t[prop];
@@ -173,6 +194,23 @@ describe('diff-viewer plan actions', () => {
     );
   });
 
+  it('`Shift+A` on an annotated item pre-fills the composer and keeps the note', () => {
+    add(PR_ID, {
+      kind: 'local',
+      id: 'd1',
+      file: 'a.ts',
+      line: 5,
+      body: 'b',
+      severity: 'minor',
+    });
+    annotate(PR_ID, 'local', 'd1', 'existing note');
+    const pane = makePane({ selectedCommentId: 'd1' });
+    handleDiffViewerInput('A', makeKey({ shift: true }), viewerCtx(pane));
+    const state = pane as unknown as Record<string, unknown>;
+    expect(state.annotationBuffer).toBe('existing note');
+    expect(list(PR_ID)[0]!.annotation).toBe('existing note');
+  });
+
   it('annotation mode: typing then Enter stores the note', () => {
     add(PR_ID, {
       kind: 'local',
@@ -192,7 +230,9 @@ describe('diff-viewer plan actions', () => {
     handleDiffViewerInput('i', makeKey(), ctx);
     handleDiffViewerInput('', makeKey({ return: true }), ctx);
     expect(list(PR_ID)[0]!.annotation).toBe('hi');
-    expect((pane as unknown as Record<string, unknown>).annotatingPlanKey).toBeNull();
+    expect(
+      (pane as unknown as Record<string, unknown>).annotatingPlanKey
+    ).toBeNull();
   });
 
   it('`c` opens the checkout pane when the plan is non-empty', () => {

--- a/apps/cli/src/screens/main/plan-input.spec.ts
+++ b/apps/cli/src/screens/main/plan-input.spec.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Key } from 'ink';
+import type { RemoteCommentThread } from '@kirby/vcs-core';
+import type { ReviewComment } from '@kirby/review-comments';
+import { handleDiffViewerInput } from './diff-viewer-input.js';
+import { handleDiffFileListInput } from './diff-file-list-input.js';
+import type {
+  DiffViewerHandlerCtx,
+  DiffFileListHandlerCtx,
+} from './input-types.js';
+import { ACTIONS, NORMIE_PRESET } from '../../keybindings/registry.js';
+import { resolveAction } from '../../keybindings/resolver.js';
+import {
+  add,
+  count,
+  has,
+  list,
+  remove,
+  toggle,
+  annotate,
+  clear,
+  __resetPlanStoreForTest,
+} from '../../plan/plan-store.js';
+
+const PR_ID = 1;
+const plan = { snapshot: new Map(), add, remove, has, toggle, annotate, list, count, clear };
+
+function makeKey(overrides: Partial<Key> = {}): Key {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    return: false,
+    escape: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    pageDown: false,
+    pageUp: false,
+    home: false,
+    end: false,
+    ctrl: false,
+    shift: false,
+    meta: false,
+    super: false,
+    hyper: false,
+    capsLock: false,
+    numLock: false,
+    ...overrides,
+  };
+}
+
+const keybinds = {
+  resolve: (input: string, key: Key, context: 'diff-viewer' | 'diff-file-list') =>
+    resolveAction(input, key, context, NORMIE_PRESET.bindings, ACTIONS),
+} as unknown as DiffViewerHandlerCtx['keybinds'];
+
+function localDraft(id = 'd1'): ReviewComment {
+  return {
+    id,
+    file: 'a.ts',
+    lineStart: 5,
+    lineEnd: 5,
+    severity: 'minor',
+    body: 'draft body',
+    side: 'RIGHT',
+    status: 'draft',
+    createdAt: '2026-01-01',
+  };
+}
+
+function remoteThread(id = 't1'): RemoteCommentThread {
+  return {
+    id,
+    file: 'a.ts',
+    lineStart: 8,
+    lineEnd: 8,
+    side: 'RIGHT',
+    isResolved: false,
+    isOutdated: false,
+    canResolve: true,
+    comments: [
+      { id: `${id}-root`, author: 'alice', body: 'root', createdAt: '2026-01-01' },
+    ],
+  };
+}
+
+// Minimal pane fake carrying only the fields the plan paths touch.
+function makePane(initial: Record<string, unknown> = {}) {
+  const state: Record<string, unknown> = {
+    paneMode: 'diff-file',
+    priorPaneMode: 'terminal',
+    diffViewFile: 'a.ts',
+    selectedCommentId: null,
+    editingCommentId: null,
+    pendingDeleteCommentId: null,
+    replyingToThreadId: null,
+    diffScrollOffset: 0,
+    diffFileIndex: 0,
+    annotatingPlanKey: null,
+    annotationBuffer: '',
+    planCheckoutIndex: 0,
+    planCheckoutTarget: null,
+    showSkipped: false,
+    ...initial,
+  };
+  return new Proxy(state, {
+    get(t, prop: string) {
+      if (prop.startsWith('set')) {
+        const field = prop[3]!.toLowerCase() + prop.slice(4);
+        return (v: unknown) => {
+          t[field] = typeof v === 'function' ? (v as (p: unknown) => unknown)(t[field]) : v;
+        };
+      }
+      return t[prop];
+    },
+  }) as unknown as DiffViewerHandlerCtx['pane'];
+}
+
+function viewerCtx(pane: DiffViewerHandlerCtx['pane']): DiffViewerHandlerCtx {
+  return {
+    pane,
+    diffFiles: [],
+    terminal: { paneRows: 40, paneCols: 80 },
+    diffTotalRows: 0,
+    rowMap: { positions: [], totalRows: 0, sectionAnchorRows: [0] },
+    sectionAnchorRows: [0],
+    commentCtx: {
+      comments: [localDraft()],
+      prId: PR_ID,
+      positions: new Map(),
+      selectedReviewPr: { id: PR_ID } as never,
+    },
+    remoteCtx: {
+      threads: [remoteThread()],
+      replyToThread: vi.fn(),
+      toggleResolved: vi.fn(),
+      refresh: vi.fn(),
+    },
+    config: { config: {} } as never,
+    sessions: { flashStatus: vi.fn() } as never,
+    asyncOps: { run: vi.fn() } as never,
+    keybinds,
+    plan,
+  } as unknown as DiffViewerHandlerCtx;
+}
+
+describe('diff-viewer plan actions', () => {
+  beforeEach(() => __resetPlanStoreForTest());
+
+  it('`a` toggles the selected local draft in the plan', () => {
+    const pane = makePane({ selectedCommentId: 'd1' });
+    const ctx = viewerCtx(pane);
+    handleDiffViewerInput('a', makeKey(), ctx);
+    expect(has(PR_ID, 'local', 'd1')).toBe(true);
+    handleDiffViewerInput('a', makeKey(), ctx);
+    expect(has(PR_ID, 'local', 'd1')).toBe(false);
+  });
+
+  it('`a` toggles the selected remote thread in the plan', () => {
+    const pane = makePane({ selectedCommentId: 't1' });
+    handleDiffViewerInput('a', makeKey(), viewerCtx(pane));
+    expect(has(PR_ID, 'remote', 't1')).toBe(true);
+  });
+
+  it('`Shift+A` adds the item and opens the note composer', () => {
+    const pane = makePane({ selectedCommentId: 'd1' });
+    handleDiffViewerInput('A', makeKey({ shift: true }), viewerCtx(pane));
+    expect(has(PR_ID, 'local', 'd1')).toBe(true);
+    expect((pane as unknown as Record<string, unknown>).annotatingPlanKey).toBe(
+      'local:d1'
+    );
+  });
+
+  it('annotation mode: typing then Enter stores the note', () => {
+    add(PR_ID, {
+      kind: 'local',
+      id: 'd1',
+      file: 'a.ts',
+      line: 5,
+      body: 'b',
+      severity: 'minor',
+    });
+    const pane = makePane({
+      selectedCommentId: 'd1',
+      annotatingPlanKey: 'local:d1',
+      annotationBuffer: '',
+    });
+    const ctx = viewerCtx(pane);
+    handleDiffViewerInput('h', makeKey(), ctx);
+    handleDiffViewerInput('i', makeKey(), ctx);
+    handleDiffViewerInput('', makeKey({ return: true }), ctx);
+    expect(list(PR_ID)[0]!.annotation).toBe('hi');
+    expect((pane as unknown as Record<string, unknown>).annotatingPlanKey).toBeNull();
+  });
+
+  it('`c` opens the checkout pane when the plan is non-empty', () => {
+    add(PR_ID, {
+      kind: 'remote',
+      id: 't1',
+      file: 'a.ts',
+      line: 8,
+      body: 'root',
+      author: 'alice',
+      replies: [],
+    });
+    const pane = makePane({ selectedCommentId: 't1' });
+    handleDiffViewerInput('c', makeKey(), viewerCtx(pane));
+    expect((pane as unknown as Record<string, unknown>).paneMode).toBe(
+      'plan-checkout'
+    );
+  });
+
+  it('`c` flashes when the plan is empty (no pane switch)', () => {
+    const pane = makePane({ selectedCommentId: 't1' });
+    const ctx = viewerCtx(pane);
+    handleDiffViewerInput('c', makeKey(), ctx);
+    expect((pane as unknown as Record<string, unknown>).paneMode).toBe(
+      'diff-file'
+    );
+    expect(ctx.sessions.flashStatus).toHaveBeenCalledWith('Plan is empty');
+  });
+});
+
+function listCtx(pane: DiffFileListHandlerCtx['pane']): DiffFileListHandlerCtx {
+  return {
+    pane,
+    diffFiles: [],
+    diffDisplayCount: 1,
+    fileCount: 0,
+    shownGeneralComments: [remoteThread('g1')],
+    keybinds,
+    remoteCtx: { replyToThread: vi.fn(), toggleResolved: vi.fn() },
+    sessions: { flashStatus: vi.fn() } as never,
+    plan,
+    prId: PR_ID,
+  } as unknown as DiffFileListHandlerCtx;
+}
+
+describe('diff-file-list plan actions', () => {
+  beforeEach(() => __resetPlanStoreForTest());
+
+  it('`a` toggles the selected footer thread in the plan', () => {
+    // diffFileIndex >= fileCount(0) selects footer comment 0.
+    const pane = makePane({ diffFileIndex: 0 });
+    handleDiffFileListInput('a', makeKey(), listCtx(pane));
+    expect(has(PR_ID, 'remote', 'g1')).toBe(true);
+  });
+});

--- a/apps/cli/src/screens/reviews/DiffFileList.tsx
+++ b/apps/cli/src/screens/reviews/DiffFileList.tsx
@@ -374,30 +374,43 @@ export const DiffFileList = memo(function DiffFileList({
           </Text>
           {shownGeneral.map((thread, idx) => {
             const pKey = planItemKey('remote', thread.id);
+            // While annotating, the composer takes the card's slot.
+            if (annotatingPlanKey === pKey) {
+              return (
+                <Box
+                  key={thread.id}
+                  flexDirection="column"
+                  borderStyle="round"
+                  borderColor="green"
+                  marginBottom={1}
+                  paddingX={1}
+                >
+                  <Text wrap="truncate-end">
+                    <Text bold color="green">
+                      EDITING NOTE
+                    </Text>
+                    <Text dimColor>{' [enter] save · [esc] cancel'}</Text>
+                  </Text>
+                  <Text wrap="wrap">
+                    {annotationBuffer ?? ''}
+                    <Text color="green">▍</Text>
+                  </Text>
+                </Box>
+              );
+            }
             return (
-              <Box key={thread.id} flexDirection="column">
-                <CommentThreadCard
-                  thread={thread}
-                  selected={
-                    selectedCommentIndex !== undefined &&
-                    selectedCommentIndex === idx
-                  }
-                  replyingToThreadId={replyingToThreadId}
-                  replyBuffer={replyBuffer}
-                  inPlan={inPlanKeys?.has(pKey) ?? false}
-                  hasAnnotation={inPlanKeys?.get(pKey) === true}
-                />
-                {annotatingPlanKey === pKey && (
-                  <Box marginLeft={2} marginBottom={1}>
-                    <Box borderStyle="round" borderColor="green" paddingX={1}>
-                      <Text>
-                        <Text color="green">{'note '}</Text>
-                        {annotationBuffer ?? ''}▍
-                      </Text>
-                    </Box>
-                  </Box>
-                )}
-              </Box>
+              <CommentThreadCard
+                key={thread.id}
+                thread={thread}
+                selected={
+                  selectedCommentIndex !== undefined &&
+                  selectedCommentIndex === idx
+                }
+                replyingToThreadId={replyingToThreadId}
+                replyBuffer={replyBuffer}
+                inPlan={inPlanKeys?.has(pKey) ?? false}
+                hasAnnotation={inPlanKeys?.get(pKey) === true}
+              />
             );
           })}
         </Box>

--- a/apps/cli/src/screens/reviews/DiffFileList.tsx
+++ b/apps/cli/src/screens/reviews/DiffFileList.tsx
@@ -11,6 +11,7 @@ import {
   CommentThreadCard,
   planCommentFooter,
 } from '../../components/CommentThread.js';
+import { planItemKey } from '../../plan/plan-types.js';
 
 function statusBadge(status: DiffFile['status']): {
   char: string;
@@ -205,6 +206,9 @@ export const DiffFileList = memo(function DiffFileList({
   selectedCommentIndex,
   replyingToThreadId,
   replyBuffer,
+  inPlanKeys,
+  annotatingPlanKey,
+  annotationBuffer,
 }: {
   files: DiffFile[];
   selectedIndex: number;
@@ -221,6 +225,11 @@ export const DiffFileList = memo(function DiffFileList({
   selectedCommentIndex?: number;
   replyingToThreadId?: string | null;
   replyBuffer?: string;
+  /** Map of `${kind}:${id}` → hasAnnotation for comments in the plan. */
+  inPlanKeys?: Map<string, boolean>;
+  /** Plan key currently being annotated (Shift+A composer target). */
+  annotatingPlanKey?: string | null;
+  annotationBuffer?: string;
 }) {
   const displayFiles = useMemo(() => {
     const { normal, skipped } = partitionFiles(files);
@@ -363,18 +372,34 @@ export const DiffFileList = memo(function DiffFileList({
           <Text bold color="blue">
             PR Comments ({generalThreads.length})
           </Text>
-          {shownGeneral.map((thread, idx) => (
-            <CommentThreadCard
-              key={thread.id}
-              thread={thread}
-              selected={
-                selectedCommentIndex !== undefined &&
-                selectedCommentIndex === idx
-              }
-              replyingToThreadId={replyingToThreadId}
-              replyBuffer={replyBuffer}
-            />
-          ))}
+          {shownGeneral.map((thread, idx) => {
+            const pKey = planItemKey('remote', thread.id);
+            return (
+              <Box key={thread.id} flexDirection="column">
+                <CommentThreadCard
+                  thread={thread}
+                  selected={
+                    selectedCommentIndex !== undefined &&
+                    selectedCommentIndex === idx
+                  }
+                  replyingToThreadId={replyingToThreadId}
+                  replyBuffer={replyBuffer}
+                  inPlan={inPlanKeys?.has(pKey) ?? false}
+                  hasAnnotation={inPlanKeys?.get(pKey) === true}
+                />
+                {annotatingPlanKey === pKey && (
+                  <Box marginLeft={2} marginBottom={1}>
+                    <Box borderStyle="round" borderColor="green" paddingX={1}>
+                      <Text>
+                        <Text color="green">{'note '}</Text>
+                        {annotationBuffer ?? ''}▍
+                      </Text>
+                    </Box>
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
         </Box>
       )}
 

--- a/apps/cli/src/screens/reviews/DiffViewer.tsx
+++ b/apps/cli/src/screens/reviews/DiffViewer.tsx
@@ -10,8 +10,25 @@ import {
   CARD_INDENT,
 } from '../../components/CommentThread.js';
 import type { RowMap } from '@kirby/review-comments';
+import { planItemKey } from '../../plan/plan-types.js';
 import { DiffRow } from './DiffRow.js';
 import { languageFromFilename } from '../../utils/language.js';
+
+// Inline single-line note composer shown under a card while the user
+// is annotating its plan item (Shift+A). Mirrors the reply composer's
+// look but in green to match the plan badge.
+function PlanAnnotateInput({ buffer }: { buffer: string }) {
+  return (
+    <Box marginLeft={CARD_INDENT + 2} marginBottom={1}>
+      <Box borderStyle="round" borderColor="green" paddingX={1}>
+        <Text>
+          <Text color="green">{'note '}</Text>
+          {buffer}▍
+        </Text>
+      </Box>
+    </Box>
+  );
+}
 
 // Separate component to isolate context subscription from memo'd parent
 function DiffViewerHints({
@@ -84,6 +101,9 @@ export const DiffViewer = memo(function DiffViewer({
   editBuffer,
   replyingToThreadId,
   replyBuffer,
+  inPlanKeys,
+  annotatingPlanKey,
+  annotationBuffer,
 }: {
   filename: string;
   annotatedLines: AnnotatedLine[];
@@ -101,6 +121,11 @@ export const DiffViewer = memo(function DiffViewer({
   editBuffer?: string;
   replyingToThreadId?: string | null;
   replyBuffer?: string;
+  /** Map of `${kind}:${id}` → hasAnnotation for comments in the plan. */
+  inPlanKeys?: Map<string, boolean>;
+  /** Plan key currently being annotated (Shift+A composer target). */
+  annotatingPlanKey?: string | null;
+  annotationBuffer?: string;
 }) {
   // Chrome: header + divider + hints = 3 lines
   const viewportHeight = Math.max(1, paneRows - 3);
@@ -177,31 +202,49 @@ export const DiffViewer = memo(function DiffViewer({
       );
     }
     if (line.type === 'thread-remote') {
+      const pKey = planItemKey('remote', line.thread.id);
+      const inPlan = inPlanKeys?.has(pKey) ?? false;
       return (
-        <CommentThreadCard
-          key={`r:${line.thread.id}`}
-          thread={line.thread}
-          selected={selectedCommentId === line.thread.id}
-          replyingToThreadId={replyingToThreadId}
-          replyBuffer={replyBuffer}
-          maxWidth={cardWidth}
-          indent={CARD_INDENT}
-        />
+        <>
+          <CommentThreadCard
+            key={`r:${line.thread.id}`}
+            thread={line.thread}
+            selected={selectedCommentId === line.thread.id}
+            replyingToThreadId={replyingToThreadId}
+            replyBuffer={replyBuffer}
+            maxWidth={cardWidth}
+            indent={CARD_INDENT}
+            inPlan={inPlan}
+            hasAnnotation={inPlanKeys?.get(pKey) === true}
+          />
+          {annotatingPlanKey === pKey && (
+            <PlanAnnotateInput buffer={annotationBuffer ?? ''} />
+          )}
+        </>
       );
     }
+    const pKey = planItemKey('local', line.comment.id);
+    const inPlan = inPlanKeys?.has(pKey) ?? false;
     return (
-      <LocalCommentCard
-        key={`l:${line.comment.id}`}
-        comment={line.comment}
-        selected={selectedCommentId === line.comment.id}
-        pendingDelete={pendingDeleteCommentId === line.comment.id}
-        editing={editingCommentId === line.comment.id}
-        editBuffer={
-          editingCommentId === line.comment.id ? editBuffer : undefined
-        }
-        maxWidth={cardWidth}
-        indent={CARD_INDENT}
-      />
+      <>
+        <LocalCommentCard
+          key={`l:${line.comment.id}`}
+          comment={line.comment}
+          selected={selectedCommentId === line.comment.id}
+          pendingDelete={pendingDeleteCommentId === line.comment.id}
+          editing={editingCommentId === line.comment.id}
+          editBuffer={
+            editingCommentId === line.comment.id ? editBuffer : undefined
+          }
+          maxWidth={cardWidth}
+          indent={CARD_INDENT}
+          inPlan={inPlan}
+          hasAnnotation={inPlanKeys?.get(pKey) === true}
+        />
+        {annotatingPlanKey === pKey && (
+          <PlanAnnotateInput buffer={annotationBuffer ?? ''} />
+        )}
+      </>
     );
   }
 

--- a/apps/cli/src/screens/reviews/DiffViewer.tsx
+++ b/apps/cli/src/screens/reviews/DiffViewer.tsx
@@ -14,18 +14,42 @@ import { planItemKey } from '../../plan/plan-types.js';
 import { DiffRow } from './DiffRow.js';
 import { languageFromFilename } from '../../utils/language.js';
 
-// Inline single-line note composer shown under a card while the user
-// is annotating its plan item (Shift+A). Mirrors the reply composer's
-// look but in green to match the plan badge.
-function PlanAnnotateInput({ buffer }: { buffer: string }) {
-  return (
-    <Box marginLeft={CARD_INDENT + 2} marginBottom={1}>
-      <Box borderStyle="round" borderColor="green" paddingX={1}>
-        <Text>
-          <Text color="green">{'note '}</Text>
-          {buffer}▍
+// Note composer shown while annotating a plan item (Shift+A). Rendered
+// *in place of* the comment card so it occupies the same slot — the card
+// is briefly obscured, which keeps the layout stable and works on small
+// terminals. Mirrors the card's indent + width so it lines up 1:1.
+function PlanAnnotateInput({
+  buffer,
+  width,
+}: {
+  buffer: string;
+  width: number;
+}) {
+  const box = (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="green"
+      marginBottom={1}
+      paddingX={1}
+      width={width}
+    >
+      <Text wrap="truncate-end">
+        <Text bold color="green">
+          EDITING NOTE
         </Text>
-      </Box>
+        <Text dimColor>{' [enter] save · [esc] cancel'}</Text>
+      </Text>
+      <Text wrap="wrap">
+        {buffer}
+        <Text color="green">▍</Text>
+      </Text>
+    </Box>
+  );
+  return (
+    <Box>
+      <Box width={CARD_INDENT} flexShrink={0} />
+      {box}
     </Box>
   );
 }
@@ -203,48 +227,55 @@ export const DiffViewer = memo(function DiffViewer({
     }
     if (line.type === 'thread-remote') {
       const pKey = planItemKey('remote', line.thread.id);
-      const inPlan = inPlanKeys?.has(pKey) ?? false;
-      return (
-        <>
-          <CommentThreadCard
-            key={`r:${line.thread.id}`}
-            thread={line.thread}
-            selected={selectedCommentId === line.thread.id}
-            replyingToThreadId={replyingToThreadId}
-            replyBuffer={replyBuffer}
-            maxWidth={cardWidth}
-            indent={CARD_INDENT}
-            inPlan={inPlan}
-            hasAnnotation={inPlanKeys?.get(pKey) === true}
+      // While annotating this item, the composer takes the card's slot.
+      if (annotatingPlanKey === pKey) {
+        return (
+          <PlanAnnotateInput
+            key={`ann:r:${line.thread.id}`}
+            buffer={annotationBuffer ?? ''}
+            width={cardWidth}
           />
-          {annotatingPlanKey === pKey && (
-            <PlanAnnotateInput buffer={annotationBuffer ?? ''} />
-          )}
-        </>
+        );
+      }
+      return (
+        <CommentThreadCard
+          key={`r:${line.thread.id}`}
+          thread={line.thread}
+          selected={selectedCommentId === line.thread.id}
+          replyingToThreadId={replyingToThreadId}
+          replyBuffer={replyBuffer}
+          maxWidth={cardWidth}
+          indent={CARD_INDENT}
+          inPlan={inPlanKeys?.has(pKey) ?? false}
+          hasAnnotation={inPlanKeys?.get(pKey) === true}
+        />
       );
     }
     const pKey = planItemKey('local', line.comment.id);
-    const inPlan = inPlanKeys?.has(pKey) ?? false;
-    return (
-      <>
-        <LocalCommentCard
-          key={`l:${line.comment.id}`}
-          comment={line.comment}
-          selected={selectedCommentId === line.comment.id}
-          pendingDelete={pendingDeleteCommentId === line.comment.id}
-          editing={editingCommentId === line.comment.id}
-          editBuffer={
-            editingCommentId === line.comment.id ? editBuffer : undefined
-          }
-          maxWidth={cardWidth}
-          indent={CARD_INDENT}
-          inPlan={inPlan}
-          hasAnnotation={inPlanKeys?.get(pKey) === true}
+    if (annotatingPlanKey === pKey) {
+      return (
+        <PlanAnnotateInput
+          key={`ann:l:${line.comment.id}`}
+          buffer={annotationBuffer ?? ''}
+          width={cardWidth}
         />
-        {annotatingPlanKey === pKey && (
-          <PlanAnnotateInput buffer={annotationBuffer ?? ''} />
-        )}
-      </>
+      );
+    }
+    return (
+      <LocalCommentCard
+        key={`l:${line.comment.id}`}
+        comment={line.comment}
+        selected={selectedCommentId === line.comment.id}
+        pendingDelete={pendingDeleteCommentId === line.comment.id}
+        editing={editingCommentId === line.comment.id}
+        editBuffer={
+          editingCommentId === line.comment.id ? editBuffer : undefined
+        }
+        maxWidth={cardWidth}
+        indent={CARD_INDENT}
+        inPlan={inPlanKeys?.has(pKey) ?? false}
+        hasAnnotation={inPlanKeys?.get(pKey) === true}
+      />
     );
   }
 

--- a/apps/cli/src/screens/reviews/PlanCheckoutPane.spec.tsx
+++ b/apps/cli/src/screens/reviews/PlanCheckoutPane.spec.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import stripAnsi from 'strip-ansi';
+import { PlanCheckoutPane } from './PlanCheckoutPane.js';
+import type { LocalPlanItem, RemotePlanItem } from '../../plan/plan-types.js';
+
+const remote: RemotePlanItem = {
+  kind: 'remote',
+  id: 't1',
+  file: 'apps/cli/src/DiffViewer.tsx',
+  line: 42,
+  body: 'memoize the loop',
+  author: 'alice',
+  replies: [],
+  annotation: 'use useMemo',
+};
+
+const local: LocalPlanItem = {
+  kind: 'local',
+  id: 'd1',
+  file: 'types.ts',
+  line: 10,
+  body: 'make severity an enum',
+  severity: 'minor',
+};
+
+describe('PlanCheckoutPane', () => {
+  it('lists items with a checkbox and title count', () => {
+    const { lastFrame } = render(
+      <PlanCheckoutPane items={[remote, local]} selectedIndex={0} paneCols={80} />
+    );
+    const out = stripAnsi(lastFrame() ?? '');
+    expect(out).toContain('Plan Checkout (2)');
+    expect(out).toContain('[x]');
+    expect(out).toContain('DiffViewer.tsx:42');
+    expect(out).toContain('[minor]');
+  });
+
+  it('shows the annotation with a ✎ marker when present', () => {
+    const { lastFrame } = render(
+      <PlanCheckoutPane items={[remote]} selectedIndex={0} paneCols={80} />
+    );
+    const out = stripAnsi(lastFrame() ?? '');
+    expect(out).toContain('✎');
+    expect(out).toContain('use useMemo');
+  });
+
+  it('renders the note composer for the annotating item', () => {
+    const { lastFrame } = render(
+      <PlanCheckoutPane
+        items={[remote]}
+        selectedIndex={0}
+        paneCols={80}
+        annotatingPlanKey="remote:t1"
+        annotationBuffer="typing"
+      />
+    );
+    const out = stripAnsi(lastFrame() ?? '');
+    expect(out).toContain('note typing');
+  });
+
+  it('renders the inject-vs-restart choice when a target is set', () => {
+    const { lastFrame } = render(
+      <PlanCheckoutPane
+        items={[remote]}
+        selectedIndex={0}
+        paneCols={80}
+        target="inject"
+      />
+    );
+    const out = stripAnsi(lastFrame() ?? '');
+    expect(out).toContain('Inject into it');
+    expect(out).toContain('Restart with plan');
+  });
+
+  it('shows an empty state', () => {
+    const { lastFrame } = render(
+      <PlanCheckoutPane items={[]} selectedIndex={0} paneCols={80} />
+    );
+    expect(stripAnsi(lastFrame() ?? '')).toContain('plan is empty');
+  });
+});

--- a/apps/cli/src/screens/reviews/PlanCheckoutPane.tsx
+++ b/apps/cli/src/screens/reviews/PlanCheckoutPane.tsx
@@ -1,0 +1,104 @@
+import { memo } from 'react';
+import { Box, Text } from 'ink';
+import { truncate } from '../../utils/truncate.js';
+import { planItemKey, type PlanItem } from '../../plan/plan-types.js';
+
+// Presentational checkout pane: a checklist of plan items with an
+// include/exclude toggle, inline note editing, and a send action. When
+// an agent is already running in the worktree, a small inject-vs-restart
+// choice replaces the checklist hints. All state is driven by props;
+// input handling lives in plan-checkout-input.ts.
+
+function locationLabel(item: PlanItem): string {
+  const file = item.file ?? 'general';
+  return item.line != null ? `${file}:${item.line}` : file;
+}
+
+export const PlanCheckoutPane = memo(function PlanCheckoutPane({
+  items,
+  selectedIndex,
+  paneCols,
+  annotatingPlanKey,
+  annotationBuffer,
+  target,
+}: {
+  items: PlanItem[];
+  selectedIndex: number;
+  paneCols: number;
+  annotatingPlanKey?: string | null;
+  annotationBuffer?: string;
+  /** When set, render the inject-vs-restart choice instead of hints. */
+  target?: 'inject' | 'new-session' | null;
+}) {
+  const bodyWidth = Math.max(20, paneCols - 8);
+
+  return (
+    <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
+      <Text bold color="blue">
+        Plan Checkout ({items.length})
+      </Text>
+      <Text dimColor>{'─'.repeat(Math.min(40, paneCols - 2))}</Text>
+
+      {items.length === 0 && <Text dimColor>(plan is empty)</Text>}
+
+      <Box flexDirection="column">
+        {items.map((item, idx) => {
+          const selected = idx === selectedIndex;
+          const key = planItemKey(item.kind, item.id);
+          const tag =
+            item.kind === 'local' ? `[${item.severity}] ` : '';
+          return (
+            <Box key={key} flexDirection="column">
+              <Text wrap="truncate-end">
+                <Text color="green">{'[x] '}</Text>
+                <Text color={selected ? 'cyan' : undefined} bold={selected}>
+                  {locationLabel(item)}
+                </Text>
+                <Text dimColor>{'  '}{tag}{truncate(item.body, bodyWidth)}</Text>
+              </Text>
+              {item.annotation && annotatingPlanKey !== key && (
+                <Text wrap="truncate-end">
+                  <Text color="green">{'    ✎ '}</Text>
+                  <Text dimColor>{truncate(item.annotation, bodyWidth)}</Text>
+                </Text>
+              )}
+              {annotatingPlanKey === key && (
+                <Box marginLeft={4} marginY={0}>
+                  <Box borderStyle="round" borderColor="green" paddingX={1}>
+                    <Text>
+                      <Text color="green">{'note '}</Text>
+                      {annotationBuffer ?? ''}▍
+                    </Text>
+                  </Box>
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Box marginTop={1}>
+        {target ? (
+          <Text>
+            <Text dimColor>An agent is already running. </Text>
+            <Text color={target === 'inject' ? 'cyan' : undefined}>
+              {target === 'inject' ? '› ' : '  '}Inject into it
+            </Text>
+            <Text dimColor>{'   '}</Text>
+            <Text color={target === 'new-session' ? 'cyan' : undefined}>
+              {target === 'new-session' ? '› ' : '  '}Restart with plan
+            </Text>
+            <Text dimColor>{'  ·  [↑/↓] choose · [enter] send · [esc] back'}</Text>
+          </Text>
+        ) : (
+          <Text dimColor>
+            <Text color="cyan">[space]</Text> remove ·{' '}
+            <Text color="cyan">[a]</Text> note ·{' '}
+            <Text color="cyan">[enter]</Text> send to agent ·{' '}
+            <Text color="cyan">[esc]</Text> back
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+});

--- a/apps/cli/src/session/checkout-plan.spec.ts
+++ b/apps/cli/src/session/checkout-plan.spec.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { PullRequestInfo } from '@kirby/vcs-core';
+import type { AppConfig, PullRequestInfo } from '@kirby/vcs-core';
 
-// Mock the PTY registry and worktree manager so the orchestrator's
-// branching is observable without spawning real processes.
+// Mock the launcher + registry so the orchestrator's branching is
+// observable without spawning real processes.
 const hasSession = vi.fn();
-const getSession = vi.fn();
-const spawnSession = vi.fn();
 vi.mock('../pty-registry.js', () => ({
   hasSession: (n: string) => hasSession(n),
-  getSession: (n: string) => getSession(n),
-  spawnSession: (...a: unknown[]) => spawnSession(...a),
+}));
+
+const launchSession = vi.fn();
+const deliverToRunningSession = vi.fn();
+vi.mock('./launch-session.js', () => ({
+  launchSession: (...a: unknown[]) => launchSession(...a),
+  deliverToRunningSession: (...a: unknown[]) => deliverToRunningSession(...a),
 }));
 
 const branchToSessionName = vi.fn((b: string) => `sess-${b}`);
@@ -19,9 +22,10 @@ vi.mock('@kirby/worktree-manager', () => ({
   createWorktree: (b: string) => createWorktree(b),
 }));
 
-import { checkoutPlan } from './checkout-orchestrator.js';
+import { checkoutPlan } from './checkout-plan.js';
 
 const pr = { id: 7, sourceBranch: 'feature/x' } as PullRequestInfo;
+const config = { vendorAuth: {}, vendorProject: {} } as AppConfig;
 
 function deps(mode: 'inject' | 'new-session', flashStatus = vi.fn()) {
   return {
@@ -30,6 +34,7 @@ function deps(mode: 'inject' | 'new-session', flashStatus = vi.fn()) {
     paneCols: 80,
     paneRows: 24,
     mode,
+    config,
     flashStatus,
   };
 }
@@ -40,46 +45,49 @@ describe('checkoutPlan', () => {
     createWorktree.mockResolvedValue('/wt/feature-x');
   });
 
-  it('State A / inject: writes to the running PTY, never spawns', async () => {
+  it('State A / inject: delivers to the running session, never spawns', async () => {
     hasSession.mockReturnValue(true);
-    const write = vi.fn();
-    getSession.mockReturnValue({ pty: { write }, exited: false });
+    deliverToRunningSession.mockReturnValue(true);
 
     const result = await checkoutPlan(deps('inject'));
 
     expect(result).toBe('injected');
-    expect(write).toHaveBeenCalledTimes(1);
-    // Prompt is submitted with a trailing carriage return, no shell-quoting.
-    expect(write).toHaveBeenCalledWith(expect.stringMatching(/\r$/));
-    expect(spawnSession).not.toHaveBeenCalled();
+    expect(deliverToRunningSession).toHaveBeenCalledWith(
+      'sess-feature/x',
+      expect.stringContaining('Resolve these PR review comments')
+    );
+    expect(launchSession).not.toHaveBeenCalled();
     expect(createWorktree).not.toHaveBeenCalled();
   });
 
-  it('State A / inject: fails when the session has exited', async () => {
+  it('State A / inject: fails when the session is no longer alive', async () => {
     hasSession.mockReturnValue(true);
-    getSession.mockReturnValue({ pty: { write: vi.fn() }, exited: true });
+    deliverToRunningSession.mockReturnValue(false);
     const flash = vi.fn();
 
     const result = await checkoutPlan(deps('inject', flash));
 
     expect(result).toBe('failed');
-    expect(spawnSession).not.toHaveBeenCalled();
+    expect(launchSession).not.toHaveBeenCalled();
     expect(flash).toHaveBeenCalled();
   });
 
-  it('State A / new-session: respawns in the existing worktree', async () => {
+  it('State A / new-session: respawns in the existing worktree with the seed intent', async () => {
     hasSession.mockReturnValue(true);
 
     const result = await checkoutPlan(deps('new-session'));
 
     expect(result).toBe('spawned');
     expect(createWorktree).toHaveBeenCalledWith('feature/x');
-    expect(spawnSession).toHaveBeenCalledTimes(1);
-    const args = spawnSession.mock.calls[0];
-    expect(args[0]).toBe('sess-feature/x');
-    // Seed command must NOT use --continue (else the plan is swallowed).
-    expect(args[2][1]).not.toContain('--continue');
-    expect(args[2][1]).toContain("claude '");
+    expect(launchSession).toHaveBeenCalledTimes(1);
+    const arg = launchSession.mock.calls[0][0];
+    expect(arg.name).toBe('sess-feature/x');
+    expect(arg.cwd).toBe('/wt/feature-x');
+    // Must seed (deliver the plan), never continue.
+    expect(arg.request).toEqual({
+      intent: 'seed',
+      prompt: expect.stringContaining('Resolve these PR review comments'),
+    });
   });
 
   it('States B/C: no running agent → create worktree + spawn', async () => {
@@ -89,8 +97,8 @@ describe('checkoutPlan', () => {
 
     expect(result).toBe('spawned');
     expect(createWorktree).toHaveBeenCalledWith('feature/x');
-    expect(spawnSession).toHaveBeenCalledTimes(1);
-    expect(spawnSession.mock.calls[0][5]).toBe('/wt/feature-x');
+    expect(launchSession).toHaveBeenCalledTimes(1);
+    expect(launchSession.mock.calls[0][0].cwd).toBe('/wt/feature-x');
   });
 
   it('fails when the worktree cannot be created', async () => {
@@ -101,17 +109,15 @@ describe('checkoutPlan', () => {
     const result = await checkoutPlan(deps('new-session', flash));
 
     expect(result).toBe('failed');
-    expect(spawnSession).not.toHaveBeenCalled();
+    expect(launchSession).not.toHaveBeenCalled();
     expect(flash).toHaveBeenCalled();
   });
 
-  it('sanitizes quotes in the seed command', async () => {
+  it('passes the prompt through verbatim — no quote stripping', async () => {
     hasSession.mockReturnValue(false);
 
     await checkoutPlan({ ...deps('new-session'), prompt: `it's "quoted"` });
 
-    const cmd = spawnSession.mock.calls[0][2][1] as string;
-    expect(cmd).not.toContain('"');
-    expect(cmd).toBe("claude 'its quoted'");
+    expect(launchSession.mock.calls[0][0].request.prompt).toBe(`it's "quoted"`);
   });
 });

--- a/apps/cli/src/session/checkout-plan.ts
+++ b/apps/cli/src/session/checkout-plan.ts
@@ -1,19 +1,25 @@
-import type { PullRequestInfo } from '@kirby/vcs-core';
+import type { AppConfig, PullRequestInfo } from '@kirby/vcs-core';
 import { branchToSessionName, createWorktree } from '@kirby/worktree-manager';
-import { getSession, hasSession, spawnSession } from '../pty-registry.js';
+import { hasSession } from '../pty-registry.js';
+import { launchSession, deliverToRunningSession } from './launch-session.js';
 
 // ── Checkout orchestration ───────────────────────────────────────
 //
-// Forwards a composed plan prompt to a Claude agent in the PR's own
-// worktree. Three states (always one agent per worktree):
+// Forwards a composed plan prompt to the configured agent in the PR's
+// own worktree. Three states (always one agent per worktree):
 //
-//   A. Agent already running → inject (pty.write, non-destructive) OR
-//      new-session (kill old + respawn), per `mode`.
+//   A. Agent already running → inject (typed into the REPL,
+//      non-destructive) OR new-session (kill old + respawn), per `mode`.
 //   B. Worktree exists, no agent → spawn seeded with the plan.
 //   C. No worktree → create it, then spawn seeded with the plan.
 //
 // States B and C are unified because `createWorktree` is idempotent —
 // it returns the existing path in B and creates one in C.
+//
+// The spawn uses the `seed` intent, never `continue`: continuing a prior
+// conversation would swallow the plan, and delivering the plan is the
+// whole point of checkout. The launcher hands the prompt to the agent as
+// argv (or env), so no shell quoting is involved.
 
 export type CheckoutResult = 'injected' | 'spawned' | 'failed';
 
@@ -25,52 +31,43 @@ export interface CheckoutDeps {
   paneRows: number;
   /** Only meaningful in State A (a running agent is present). */
   mode: 'inject' | 'new-session';
+  /** Drives which agent is launched. */
+  config: AppConfig;
   flashStatus: (msg: string) => void;
 }
 
-/**
- * Build the shell command that spawns a fresh Claude seeded with the
- * plan. We deliberately do NOT use `claude --continue` here: continuing
- * a prior conversation would swallow the seed prompt, and the whole
- * point of checkout is to deliver the plan. Single-quote the sanitized
- * prompt as one argv entry to `/bin/sh -c`.
- */
-function seedCommand(prompt: string): string {
-  const safePrompt = prompt.replace(/['"]/g, '');
-  return `claude '${safePrompt}'`;
-}
-
-export async function checkoutPlan(deps: CheckoutDeps): Promise<CheckoutResult> {
-  const { pr, prompt, paneCols, paneRows, mode, flashStatus } = deps;
+export async function checkoutPlan(
+  deps: CheckoutDeps
+): Promise<CheckoutResult> {
+  const { pr, prompt, paneCols, paneRows, mode, config, flashStatus } = deps;
   const name = branchToSessionName(pr.sourceBranch);
+
+  const seed = (cwd: string) =>
+    launchSession({
+      name,
+      cwd,
+      cols: paneCols,
+      rows: paneRows,
+      config,
+      request: { intent: 'seed', prompt },
+    });
 
   // ── State A: an agent is already running in this worktree ──
   if (hasSession(name)) {
     if (mode === 'inject') {
-      const entry = getSession(name);
-      if (!entry || entry.exited) {
+      if (!deliverToRunningSession(name, prompt)) {
         flashStatus('Agent is no longer running');
         return 'failed';
       }
-      // Write directly into the running REPL. No shell-quoting — this
-      // is typed input, and the trailing CR submits it.
-      entry.pty.write(prompt + '\r');
       return 'injected';
     }
-    // new-session: reseed. spawnSession kills the same-name PTY first.
+    // new-session: reseed. launchSession kills the same-name PTY first.
     const worktreePath = await createWorktree(pr.sourceBranch);
     if (!worktreePath) {
       flashStatus(`Failed to resolve worktree for ${pr.sourceBranch}`);
       return 'failed';
     }
-    spawnSession(
-      name,
-      '/bin/sh',
-      ['-c', seedCommand(prompt)],
-      paneCols,
-      paneRows,
-      worktreePath
-    );
+    seed(worktreePath);
     return 'spawned';
   }
 
@@ -80,13 +77,6 @@ export async function checkoutPlan(deps: CheckoutDeps): Promise<CheckoutResult> 
     flashStatus(`Failed to create worktree for ${pr.sourceBranch}`);
     return 'failed';
   }
-  spawnSession(
-    name,
-    '/bin/sh',
-    ['-c', seedCommand(prompt)],
-    paneCols,
-    paneRows,
-    worktreePath
-  );
+  seed(worktreePath);
   return 'spawned';
 }

--- a/apps/cli/src/session/launch-session.spec.ts
+++ b/apps/cli/src/session/launch-session.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// buildLaunchSpec is pure, but the module imports pty-registry (→ node-pty).
+// Mock it so these stay fast, dependency-free unit tests.
+vi.mock('../pty-registry.js', () => ({
+  spawnSession: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+import { buildLaunchSpec } from './launch-session.js';
+import type { AgentDefinition } from '../agents/registry.js';
+
+const claude: AgentDefinition = {
+  id: 'claude',
+  name: 'Claude',
+  supportsAppendSystemPrompt: true,
+  blank: () => ({ cmd: 'claude', args: [] }),
+  seed: (p, o) =>
+    o?.appendSystemPrompt
+      ? {
+          cmd: 'claude',
+          args: ['--append-system-prompt', o.appendSystemPrompt, p],
+        }
+      : { cmd: 'claude', args: [p] },
+  continueOrBlank: () => ({
+    cmd: '/bin/sh',
+    args: ['-c', 'claude --continue || claude'],
+  }),
+  continueOrSeed: (p) => ({
+    cmd: '/bin/sh',
+    args: ['-c', 'claude --continue || claude "$KIRBY_SEED_PROMPT"'],
+    env: { KIRBY_SEED_PROMPT: p },
+  }),
+};
+
+// A no-continue, no-append agent (like Copilot).
+const copilot: AgentDefinition = {
+  id: 'copilot',
+  name: 'Copilot',
+  supportsAppendSystemPrompt: false,
+  blank: () => ({ cmd: 'copilot', args: [] }),
+  seed: (p) => ({ cmd: 'copilot', args: ['-i', p] }),
+};
+
+// An agent that can't seed at all — exercises the blank fallback.
+const blankOnly: AgentDefinition = {
+  id: 'test',
+  name: 'Blank Only',
+  supportsAppendSystemPrompt: false,
+  blank: () => ({ cmd: 'noop', args: [] }),
+};
+
+describe('buildLaunchSpec', () => {
+  it('blank → agent.blank()', () => {
+    expect(buildLaunchSpec(claude, { intent: 'blank' })).toEqual({
+      cmd: 'claude',
+      args: [],
+    });
+  });
+
+  it('continue-or-blank uses continueOrBlank when available', () => {
+    expect(buildLaunchSpec(claude, { intent: 'continue-or-blank' })).toEqual({
+      cmd: '/bin/sh',
+      args: ['-c', 'claude --continue || claude'],
+    });
+  });
+
+  it('continue-or-blank degrades to blank when the agent has no continue', () => {
+    expect(buildLaunchSpec(copilot, { intent: 'continue-or-blank' })).toEqual({
+      cmd: 'copilot',
+      args: [],
+    });
+  });
+
+  it('seed passes the prompt through', () => {
+    expect(
+      buildLaunchSpec(copilot, { intent: 'seed', prompt: 'do it' })
+    ).toEqual({ cmd: 'copilot', args: ['-i', 'do it'] });
+  });
+
+  it('seed degrades to blank when the agent cannot seed', () => {
+    expect(
+      buildLaunchSpec(blankOnly, { intent: 'seed', prompt: 'do it' })
+    ).toEqual({ cmd: 'noop', args: [] });
+  });
+
+  it('continue-or-seed degrades to seed when the agent has no continue', () => {
+    expect(
+      buildLaunchSpec(copilot, { intent: 'continue-or-seed', prompt: 'do it' })
+    ).toEqual({ cmd: 'copilot', args: ['-i', 'do it'] });
+  });
+
+  describe('system guidance', () => {
+    it('is passed natively for append-capable agents (Claude)', () => {
+      const spec = buildLaunchSpec(claude, {
+        intent: 'seed',
+        prompt: 'review this',
+        systemGuidance: 'use add-comment',
+      });
+      expect(spec).toEqual({
+        cmd: 'claude',
+        args: ['--append-system-prompt', 'use add-comment', 'review this'],
+      });
+    });
+
+    it('is folded into the prompt for non-append agents', () => {
+      const spec = buildLaunchSpec(copilot, {
+        intent: 'seed',
+        prompt: 'review this',
+        systemGuidance: 'use add-comment',
+      });
+      expect(spec).toEqual({
+        cmd: 'copilot',
+        args: ['-i', 'use add-comment\n\nreview this'],
+      });
+    });
+
+    it('threads guidance through Claude continue-or-seed via env', () => {
+      const withOpts: AgentDefinition = {
+        ...claude,
+        continueOrSeed: (p, o) => ({
+          cmd: '/bin/sh',
+          args: [
+            '-c',
+            o?.appendSystemPrompt
+              ? 'claude --continue || claude --append-system-prompt "$KIRBY_SEED_SYSTEM" "$KIRBY_SEED_PROMPT"'
+              : 'claude --continue || claude "$KIRBY_SEED_PROMPT"',
+          ],
+          env: {
+            KIRBY_SEED_PROMPT: p,
+            ...(o?.appendSystemPrompt
+              ? { KIRBY_SEED_SYSTEM: o.appendSystemPrompt }
+              : {}),
+          },
+        }),
+      };
+      const spec = buildLaunchSpec(withOpts, {
+        intent: 'continue-or-seed',
+        prompt: 'the task',
+        systemGuidance: 'the guidance',
+      });
+      expect(spec.env).toEqual({
+        KIRBY_SEED_PROMPT: 'the task',
+        KIRBY_SEED_SYSTEM: 'the guidance',
+      });
+    });
+  });
+});

--- a/apps/cli/src/session/launch-session.ts
+++ b/apps/cli/src/session/launch-session.ts
@@ -1,0 +1,118 @@
+import type { AppConfig } from '@kirby/vcs-core';
+import { spawnSession, getSession, type PtyEntry } from '../pty-registry.js';
+import {
+  resolveAgent,
+  type AgentDefinition,
+  type LaunchSpec,
+  type SeedOptions,
+} from '../agents/registry.js';
+
+// ── Session launcher ─────────────────────────────────────────────
+//
+// The single place that turns a high-level intent ("start a blank
+// session", "seed a review", "resume or seed") plus the configured
+// agent into a concrete PTY spawn. Every spawn call site routes through
+// here so they all honor `config.agentId` and never hardcode `claude`
+// or hand-build shell strings.
+
+export type LaunchIntent =
+  | 'blank'
+  | 'continue-or-blank'
+  | 'seed'
+  | 'continue-or-seed';
+
+export interface LaunchRequest {
+  intent: LaunchIntent;
+  /** Required for `seed` / `continue-or-seed`. */
+  prompt?: string;
+  /**
+   * Optional guidance (e.g. "here's how to use Kirby's add-comment
+   * command"). Delivered as a native system prompt for agents that
+   * support it (Claude), folded into the prompt for the rest.
+   */
+  systemGuidance?: string;
+}
+
+function foldGuidance(
+  agent: AgentDefinition,
+  prompt: string,
+  guidance: string | undefined
+): { prompt: string; opts: SeedOptions | undefined } {
+  if (!guidance) return { prompt, opts: undefined };
+  if (agent.supportsAppendSystemPrompt) {
+    return { prompt, opts: { appendSystemPrompt: guidance } };
+  }
+  return { prompt: `${guidance}\n\n${prompt}`, opts: undefined };
+}
+
+/**
+ * Build the concrete {@link LaunchSpec} for an agent + request. Pure —
+ * no spawning — so it's unit-testable. Degrades safely when the agent
+ * lacks a capability (continue → blank/seed, seed → blank).
+ */
+export function buildLaunchSpec(
+  agent: AgentDefinition,
+  req: LaunchRequest
+): LaunchSpec {
+  switch (req.intent) {
+    case 'blank':
+      return agent.blank();
+    case 'continue-or-blank':
+      return agent.continueOrBlank?.() ?? agent.blank();
+    case 'seed':
+    case 'continue-or-seed': {
+      const { prompt, opts } = foldGuidance(
+        agent,
+        req.prompt ?? '',
+        req.systemGuidance
+      );
+      if (req.intent === 'continue-or-seed') {
+        return (
+          agent.continueOrSeed?.(prompt, opts) ??
+          agent.seed?.(prompt, opts) ??
+          agent.blank()
+        );
+      }
+      return agent.seed?.(prompt, opts) ?? agent.blank();
+    }
+  }
+}
+
+export interface LaunchSessionParams {
+  name: string;
+  cwd: string;
+  cols: number;
+  rows: number;
+  config: AppConfig;
+  request: LaunchRequest;
+}
+
+/**
+ * Resolve the configured agent, build its launch spec for the request,
+ * and spawn the PTY. Returns the created entry.
+ */
+export function launchSession(params: LaunchSessionParams): PtyEntry {
+  const agent = resolveAgent(params.config);
+  const spec = buildLaunchSpec(agent, params.request);
+  return spawnSession(
+    params.name,
+    spec.cmd,
+    spec.args,
+    params.cols,
+    params.rows,
+    params.cwd,
+    spec.env
+  );
+}
+
+/**
+ * Deliver a prompt to an already-running session by typing it into the
+ * REPL (non-destructive). The trailing carriage return submits it.
+ * Returns false if the session isn't alive.
+ */
+export function deliverToRunningSession(name: string, prompt: string): boolean {
+  const entry = getSession(name);
+  if (!entry || entry.exited) return false;
+  entry.pty.write(prompt + '\r');
+  return true;
+}

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -8,7 +8,8 @@ export type PaneMode =
   | 'diff'
   | 'diff-file'
   | 'comments'
-  | 'confirm';
+  | 'confirm'
+  | 'plan-checkout';
 
 export type ReviewCategory = 'needs-review' | 'waiting' | 'approved';
 

--- a/apps/cli/src/utils/plan-annotate-mode.ts
+++ b/apps/cli/src/utils/plan-annotate-mode.ts
@@ -1,0 +1,67 @@
+import type { Key } from 'ink';
+import { handleTextInput } from './handle-text-input.js';
+import type { PlanValue } from '../context/PlanContext.js';
+import type { PlanItem } from '../plan/plan-types.js';
+
+// Shared plan-annotation input handling.
+//
+// Three surfaces host the same single-line note composer: the diff
+// viewer (Shift+A), the diff file list (Shift+A), and the checkout
+// pane ([a] on a row). All operate on an item already in the plan,
+// identified by `annotatingPlanKey` (a `${kind}:${id}` key). Enter
+// commits the note, Esc cancels, any other key edits the buffer.
+
+export interface PlanAnnotatePane {
+  annotatingPlanKey: string | null;
+  annotationBuffer: string;
+  setAnnotatingPlanKey: (key: string | null) => void;
+  setAnnotationBuffer: (next: string | ((prev: string) => string)) => void;
+}
+
+export interface PlanAnnotateDeps {
+  pane: PlanAnnotatePane;
+  plan: PlanValue;
+  prId: number | undefined;
+}
+
+/** Split a `${kind}:${id}` plan key back into its parts. */
+function parseKey(key: string): { kind: PlanItem['kind']; id: string } | null {
+  const idx = key.indexOf(':');
+  if (idx < 0) return null;
+  const kind = key.slice(0, idx);
+  if (kind !== 'remote' && kind !== 'local') return null;
+  return { kind, id: key.slice(idx + 1) };
+}
+
+/**
+ * Returns `true` when the input was consumed by annotation mode (caller
+ * should return without running its normal dispatch). Returns `false`
+ * when annotation mode isn't active — caller proceeds as usual.
+ */
+export function handlePlanAnnotateInput(
+  input: string,
+  key: Key,
+  deps: PlanAnnotateDeps
+): boolean {
+  const { pane, plan, prId } = deps;
+  if (!pane.annotatingPlanKey) return false;
+
+  if (key.escape) {
+    pane.setAnnotatingPlanKey(null);
+    pane.setAnnotationBuffer('');
+    return true;
+  }
+
+  if (key.return) {
+    const parsed = parseKey(pane.annotatingPlanKey);
+    if (parsed && prId != null) {
+      plan.annotate(prId, parsed.kind, parsed.id, pane.annotationBuffer);
+    }
+    pane.setAnnotatingPlanKey(null);
+    pane.setAnnotationBuffer('');
+    return true;
+  }
+
+  handleTextInput(input, key, pane.setAnnotationBuffer);
+  return true;
+}

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -16,6 +16,12 @@
   ],
   "references": [
     {
+      "path": "../../libs/review-comments/tsconfig.lib.json"
+    },
+    {
+      "path": "../../libs/diff/tsconfig.lib.json"
+    },
+    {
       "path": "../../libs/worktree-manager/tsconfig.lib.json"
     },
     {

--- a/libs/vcs/core/src/lib/config-store.ts
+++ b/libs/vcs/core/src/lib/config-store.ts
@@ -3,7 +3,12 @@ import { execSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
-import type { AppConfig, KeyDescriptorConfig, VcsProvider } from './types.js';
+import type {
+  AgentId,
+  AppConfig,
+  KeyDescriptorConfig,
+  VcsProvider,
+} from './types.js';
 
 const WM_DIR = join(homedir(), '.kirby');
 const GLOBAL_CONFIG_PATH = join(WM_DIR, 'config.json');
@@ -42,6 +47,7 @@ interface RawGlobalConfig {
   pat?: string;
   prPollInterval?: number;
   aiCommand?: string;
+  agentId?: AgentId;
   vendorAuth?: Record<string, Record<string, string>>;
   autoDeleteOnMerge?: boolean;
   autoRebase?: boolean;
@@ -132,6 +138,7 @@ export function readConfig(cwd = process.cwd()): AppConfig {
     email: project.email,
     prPollInterval: global.prPollInterval,
     aiCommand: global.aiCommand,
+    agentId: global.agentId,
     vendor,
     vendorAuth,
     vendorProject,

--- a/libs/vcs/core/src/lib/types.ts
+++ b/libs/vcs/core/src/lib/types.ts
@@ -157,10 +157,26 @@ export interface KeyDescriptorConfig {
   meta?: boolean;
 }
 
+/**
+ * The AI agents Kirby knows how to drive natively (blank / seed /
+ * continue with per-agent capabilities). A hidden `test` runner exists
+ * in the CLI registry for e2e tests but is intentionally NOT part of
+ * this public union — it is never written to a user's config.
+ */
+export type AgentId = 'claude' | 'copilot' | 'codex' | 'gemini' | 'opencode';
+
 export interface AppConfig {
   email?: string;
   prPollInterval?: number;
+  /**
+   * Legacy raw agent command (run via `sh -c`). Still honored: when
+   * `agentId` is unset it is mapped back to a known agent, and any
+   * unrecognized command routes to the hidden test runner (used by the
+   * e2e harness). New configs should prefer `agentId`.
+   */
   aiCommand?: string;
+  /** Selected AI agent. Takes precedence over `aiCommand` when set. */
+  agentId?: AgentId;
   vendor?: string;
   vendorAuth: Record<string, string>;
   vendorProject: Record<string, string>;


### PR DESCRIPTION
## Summary

Two capabilities for turning PR review into agent-driven work.

## PR-review plan → checkout workflow

An "add-to-cart" flow for review comments. While reading a PR's diff, you collect
comments (local drafts or remote threads) into a per-PR plan, optionally attach a
note to each, then check out a worktree and hand the composed plan to an agent as
a seed prompt.

- **Plan store & types** (`plan/plan-store.ts`, `plan/plan-types.ts`) — a
  per-PR, in-memory, copy-on-write store exposed through `useSyncExternalStore`.
  Items are keyed by kind + id; annotations attach to an item and survive
  re-snapshotting so a comment's latest text and the user's note stay in sync.
  The plan is cleared after a successful checkout.
- **Prompt composer** (`plan/prompt-composer.ts`) — renders the plan (comments +
  notes) into the seed prompt handed to the agent.
- **Keybindings & input** — `a` toggles the selected comment in the plan,
  `Shift+A` adds it and opens the note composer (pre-filled with any existing
  note), `c` opens the checkout pane. Wired into both the diff viewer and the
  diff file list.
- **Checkout pane** (`screens/reviews/PlanCheckoutPane.tsx`) + orchestration
  (`session/checkout-plan.ts`) — either injects the plan into a running session
  for the branch or spawns a new worktree + session seeded with the plan.
- **Top-right overlay** (`TopRightOverlay`) stacks the plan badge, async-op
  indicator, and toasts in one place.

## Capability-aware agent registry + session launcher

A registry describing each supported agent's capabilities, so sessions launch the
configured agent and deliver prompts safely rather than assuming a single tool.

- **Registry** (`agents/registry.ts`) — Claude, Codex, Gemini, Copilot, and
  OpenCode, each declaring how it starts blank, seeds a prompt, continues a prior
  session, and whether it accepts an appended system prompt. A hidden `test`
  agent runs raw commands (used by e2e); an `aiCommand` that matches no known
  agent routes to it.
- **Launcher** (`session/launch-session.ts`) — resolves the configured agent,
  builds a launch spec for the requested intent (blank / seed / continue), and
  degrades gracefully when an agent lacks a capability (continue → seed → blank).
  Prompts are delivered as argv or environment values so quoting and special
  characters are preserved.
- Session spawn sites all go through the launcher, and the settings panel lists
  AI presets derived from the registry.