### PR TITLE
Set up manual npm publishing for kirby

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,3 +270,38 @@ This adds the blocking status without duplicating any inline comments.
 - **Don't use `gh pr review`** for inline comments — it only supports a single body comment, not per-line annotations
 - **Line numbers come from the new file**, not diff positions — count from the `@@` hunk headers to get them right
 - **Heredoc quoting matters** — use `<<'EOF'` (quoted) to prevent shell expansion inside the JSON body
+
+## Publishing to NPM
+
+Published as `@hermannbjorgvin/kirby`. All releases are beta-only and published manually from a local machine — there is no CI workflow for this.
+
+Users install with: `npm install -g @hermannbjorgvin/kirby@beta`
+
+### One-time setup
+
+- `npm login` on your machine. `npm whoami` must resolve to an account that owns the `@hermannbjorgvin` scope.
+
+### How to publish a beta version
+
+1. Bump the version in `apps/cli/package.json`. Every version must end in `-beta.N`:
+   - Patch: `0.0.1-beta.2` or `0.0.2-beta.1`
+   - Minor: `0.1.0-beta.1`
+   - Major: `1.0.0-beta.1`
+
+2. Commit the bump:
+   ```bash
+   git commit apps/cli/package.json -m "chore: bump kirby to 0.0.1-beta.2"
+   ```
+
+3. Publish:
+   ```bash
+   npx nx run cli:publish
+   ```
+
+   This runs `build` → `node apps/cli/scripts/prepare-publish.mjs` → `npm publish --tag beta apps/cli/dist`. The `--tag beta` flag keeps the release off the default `latest` dist-tag so users must explicitly opt in with `@beta`.
+
+### Build details
+
+`npx nx build cli` bundles all workspace libs (`@kirby/*`) and npm deps into a single `apps/cli/dist/main.js` with a `#!/usr/bin/env node` shebang. Only `node-pty` is kept external (it's a native module).
+
+The build copies the source `apps/cli/package.json` into `dist/` via its `assets` config — that copy is fine for `install-global` but carries workspace `@kirby/*` deps that don't exist on the npm registry. So `apps/cli/scripts/prepare-publish.mjs` rewrites `dist/package.json` just before publishing, keeping only the fields needed for npm (name, version, bin, etc.) and `node-pty` as the sole runtime dependency.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,10 +1,23 @@
 {
-  "name": "@kirby/cli",
-  "version": "0.0.1",
-  "private": true,
+  "name": "@hermannbjorgvin/kirby",
+  "version": "1.0.0-beta.1",
+  "description": "A TUI workflow manager for git worktrees",
+  "author": "Hermann Bjorgvin",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "kirby": "./main.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HermannBjorgvin/kirby.git",
+    "directory": "apps/cli"
   },
   "nx": {
     "name": "cli",
@@ -97,6 +110,19 @@
         "executor": "nx:run-commands",
         "options": {
           "command": "chmod +x apps/cli/dist/main.js && npm install -g ./apps/cli/dist"
+        }
+      },
+      "publish": {
+        "dependsOn": [
+          "build"
+        ],
+        "executor": "nx:run-commands",
+        "options": {
+          "commands": [
+            "node apps/cli/scripts/prepare-publish.mjs",
+            "npm publish --tag beta apps/cli/dist"
+          ],
+          "parallel": false
         }
       },
       "serve": {

--- a/apps/cli/scripts/prepare-publish.mjs
+++ b/apps/cli/scripts/prepare-publish.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Rewrites apps/cli/dist/package.json into a minimal, publish-safe package.
+// The build copies the source package.json into dist/ (via the build's
+// `assets` config) for local use (e.g. `npm install -g ./apps/cli/dist`),
+// but that file carries workspace `@kirby/*` deps that don't exist on the
+// npm registry, plus dev deps and nx config bloat. This strips all of it.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distPkgPath = resolve(__dirname, '../dist/package.json');
+const src = JSON.parse(readFileSync(distPkgPath, 'utf8'));
+
+// node-pty is the only runtime dep kept external by esbuild (native module).
+// Everything else — ink, react, @kirby/*, @inkjs/ui, @mishieck/ink-titled-box
+// — is bundled into dist/main.js.
+const nodePtyVersion = src.dependencies?.['node-pty'];
+if (!nodePtyVersion) {
+  throw new Error('node-pty missing from source dependencies');
+}
+
+const out = {
+  name: src.name,
+  version: src.version,
+  description: src.description,
+  author: src.author,
+  license: src.license,
+  type: src.type,
+  bin: src.bin,
+  files: ['main.js'],
+  publishConfig: src.publishConfig,
+  engines: src.engines,
+  repository: src.repository,
+  dependencies: { 'node-pty': nodePtyVersion },
+};
+
+writeFileSync(distPkgPath, JSON.stringify(out, null, 2) + '\n');
+console.log(`Prepared ${distPkgPath} for publish (name=${out.name}@${out.version})`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,9 @@
       }
     },
     "apps/cli": {
-      "name": "@kirby/cli",
-      "version": "0.0.1",
+      "name": "@hermannbjorgvin/kirby",
+      "version": "1.0.0-beta.1",
+      "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
         "@kirby/logger": "*",
@@ -69,6 +70,9 @@
       "devDependencies": {
         "@types/react": "^19.2.14",
         "tsx": "^4.21.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "apps/cli-e2e": {
@@ -2069,6 +2073,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hermannbjorgvin/kirby": {
+      "resolved": "apps/cli",
+      "link": true
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "dev": true,
@@ -2610,10 +2618,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@kirby/cli": {
-      "resolved": "apps/cli",
-      "link": true
     },
     "node_modules/@kirby/cli-e2e": {
       "resolved": "apps/cli-e2e",


### PR DESCRIPTION
## Summary

Kirby publishes to npm as `@hermannbjorgvin/kirby`, entirely from a local machine — there is no CI/CD workflow for this. Releases are beta-only: `npm publish --tag beta` keeps them off the `latest` dist-tag, so users install with `npm install -g @hermannbjorgvin/kirby@beta`.

- **`apps/cli/package.json`** — package metadata (name, description, author, license, repository, engines), version set to the first release `1.0.0-beta.1`, and a new `publish` nx target (`build` → `prepare-publish.mjs` → `npm publish --tag beta apps/cli/dist`).
- **`apps/cli/scripts/prepare-publish.mjs`** — rewrites the bundled `dist/package.json` into a minimal, publish-safe package: strips workspace `@kirby/*` deps and dev tooling, keeps `node-pty` as the sole runtime dependency (the only thing esbuild can't bundle, since it's a native module).
- **`CLAUDE.md`** — documents the one-time `npm login` setup, the version-bump + commit + `npx nx run cli:publish` release flow, and how the build/prepare-publish pipeline produces a clean `dist/` (never committed — `dist/` is gitignored and rebuilt fresh on every publish).

## Test plan

- [ ] Run `npx nx run cli:publish` and confirm `@hermannbjorgvin/kirby@1.0.0-beta.1` appears on npm under the `beta` tag
- [ ] `npm install -g @hermannbjorgvin/kirby@beta` on a clean machine and confirm `kirby` launches