### PR TITLE
fix(cli): bundle third-party deps into the published kirby binary

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermannbjorgvin/kirby",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A TUI workflow manager for git worktrees",
   "author": "Hermann Bjorgvin",
   "license": "MIT",
@@ -39,6 +39,7 @@
             "esm"
           ],
           "bundle": true,
+          "thirdParty": true,
           "external": [
             "node-pty"
           ],
@@ -50,7 +51,10 @@
           ],
           "esbuildOptions": {
             "banner": {
-              "js": "#!/usr/bin/env node"
+              "js": "#!/usr/bin/env node\nimport { createRequire as __kirbyCreateRequire } from \"node:module\";\nconst require = __kirbyCreateRequire(import.meta.url);"
+            },
+            "alias": {
+              "react-devtools-core": "./apps/cli/scripts/react-devtools-core.stub.mjs"
             },
             "sourcemap": true,
             "outExtension": {
@@ -63,7 +67,10 @@
           "production": {
             "esbuildOptions": {
               "banner": {
-                "js": "#!/usr/bin/env node"
+                "js": "#!/usr/bin/env node\nimport { createRequire as __kirbyCreateRequire } from \"node:module\";\nconst require = __kirbyCreateRequire(import.meta.url);"
+              },
+              "alias": {
+                "react-devtools-core": "./apps/cli/scripts/react-devtools-core.stub.mjs"
               },
               "sourcemap": false,
               "outExtension": {

--- a/apps/cli/scripts/react-devtools-core.stub.mjs
+++ b/apps/cli/scripts/react-devtools-core.stub.mjs
@@ -1,0 +1,10 @@
+// Build-time stand-in for `react-devtools-core`, wired up via the esbuild
+// `alias` option in the build target. Ink only imports the real package when
+// DEV=true, but bundling to a single ESM file hoists that import to the top
+// level, where Node would try to resolve it at startup. Aliasing to this stub
+// keeps the bundle self-contained; the no-op methods match the two calls in
+// ink's devtools.js.
+export default {
+  initialize() {},
+  connectToDevTools() {},
+};

--- a/apps/cli/scripts/react-devtools-core.stub.mjs
+++ b/apps/cli/scripts/react-devtools-core.stub.mjs
@@ -5,6 +5,10 @@
 // keeps the bundle self-contained; the no-op methods match the two calls in
 // ink's devtools.js.
 export default {
-  initialize() {},
-  connectToDevTools() {},
+  initialize() {
+    // intentionally empty — devtools are never connected in the bundled CLI
+  },
+  connectToDevTools() {
+    // intentionally empty — devtools are never connected in the bundled CLI
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
     },
     "apps/cli": {
       "name": "@hermannbjorgvin/kirby",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
@@ -12848,7 +12848,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12866,7 +12865,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12884,7 +12882,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12902,7 +12899,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12920,7 +12916,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12938,7 +12933,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12956,7 +12950,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12974,7 +12967,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12992,7 +12984,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13010,7 +13001,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13028,7 +13018,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13046,7 +13035,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13064,7 +13052,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13082,7 +13069,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13100,7 +13086,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13118,7 +13103,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13134,7 +13118,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13152,7 +13135,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13170,7 +13152,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13188,7 +13169,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13206,7 +13186,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13224,7 +13203,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13242,7 +13220,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## Summary

`npm install -g @hermannbjorgvin/kirby@beta` produced a binary that crashed on startup with `ERR_MODULE_NOT_FOUND: Cannot find package 'react'`. The published `main.js` had bare imports for every third-party package (react, ink, @inkjs/ui, cli-highlight, @xterm/headless, …) while the published `package.json` declares only `node-pty` — so nothing beyond node-pty could resolve on a clean install.

The `@nx/esbuild` executor externalizes all npm dependencies unless `thirdParty` is set (`esbuild.impl.js` pushes every project-graph dep into esbuild's `external` list), so `"bundle": true` only ever bundled the `@kirby/*` workspace libs. The published bundle was 376 KB; a self-contained one is ~4.5 MB.

## Changes

- **`thirdParty: true`** on the `build` target (`apps/cli/package.json`) so esbuild bundles npm deps into `dist/main.js`. `node-pty` remains the sole external (native module) and the sole runtime dependency in the published package.
- **`react-devtools-core` aliased to a no-op stub** (`apps/cli/scripts/react-devtools-core.stub.mjs`). Ink imports this optional peer dep lazily behind `DEV=true`, but single-file ESM bundling hoists the import to an eager top-level one that Node resolves at startup. The stub mirrors the two calls ink makes (`initialize`, `connectToDevTools`).
- **`createRequire` shim in the esbuild banner** (after the shebang, in both build configurations). Bundled CJS deps contain `require("stream")`-style calls that esbuild's ESM output turns into a throwing shim unless a real `require` is in scope.
- Version bumped to `1.0.0-beta.2` for the republish.

## Verification

Reproduced the full publish path locally, which CI doesn't cover: `nx build cli` → `prepare-publish.mjs` → `npm pack apps/cli/dist` → installed the tarball into an isolated global prefix → the installed `kirby` bin launches and renders the TUI. The bundle's only remaining bare imports are `node:*` builtins and `node-pty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)