### PR TITLE
feat(cli): title the terminal window after the repo

### DIFF
--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -7,6 +7,11 @@ import { DeleteConfirmModal } from './components/DeleteConfirmModal.js';
 import { OnboardingWizard } from './components/OnboardingWizard.js';
 import { killAll } from './pty-registry.js';
 import { settlePendingRuns } from './hooks/useAsyncOperation.js';
+import {
+  repoTitle,
+  setWindowTitle,
+  restoreWindowTitle,
+} from './utils/window-title.js';
 import { ConfigProvider, useConfig } from './context/ConfigContext.js';
 import { KeybindProvider } from './context/KeybindContext.js';
 import { NavProvider, useNavState } from './context/NavContext.js';
@@ -110,7 +115,13 @@ if (targetDir) {
   process.chdir(targetDir);
 }
 
-process.on('exit', killAll);
+// Name the tab after the repo, so a terminal full of Kirbys is legible.
+setWindowTitle(repoTitle());
+
+process.on('exit', () => {
+  killAll();
+  restoreWindowTitle();
+});
 process.on('SIGINT', () => {
   killAll();
   process.exit(0);

--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -116,7 +116,10 @@ if (targetDir) {
 }
 
 // Name the tab after the repo, so a terminal full of Kirbys is legible.
-setWindowTitle(repoTitle());
+// Skip the git lookup entirely when there's no TTY to title (CI, pipes).
+if (process.stdout.isTTY) {
+  setWindowTitle(repoTitle());
+}
 
 process.on('exit', () => {
   killAll();

--- a/apps/cli/src/utils/window-title.spec.ts
+++ b/apps/cli/src/utils/window-title.spec.ts
@@ -1,0 +1,127 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  repoTitle,
+  setWindowTitle,
+  restoreWindowTitle,
+} from './window-title.js';
+
+describe('repoTitle', () => {
+  let tmp: string;
+  let repo: string;
+
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync('git', args, { cwd, stdio: 'ignore' });
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'kirby-window-title-'));
+    repo = join(tmp, 'my-repo');
+    mkdirSync(repo);
+
+    git(repo, 'init', '-b', 'master');
+    git(repo, 'config', 'user.email', 'test@example.com');
+    git(repo, 'config', 'user.name', 'Test');
+    git(repo, 'commit', '--allow-empty', '-m', 'init');
+  });
+
+  afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it('names the repo root directory', () => {
+    expect(repoTitle(repo)).toBe('my-repo');
+  });
+
+  it('names the parent repo when run from inside a worktree', () => {
+    const wt = join(repo, '.claude/worktrees/feature-x');
+    git(repo, 'worktree', 'add', '-b', 'feature/x', wt);
+
+    expect(repoTitle(wt)).toBe('my-repo');
+  });
+
+  it('falls back to the directory name outside a git repo', () => {
+    const plain = join(tmp, 'not-a-repo');
+    mkdirSync(plain);
+
+    expect(repoTitle(plain)).toBe('not-a-repo');
+  });
+});
+
+describe('setWindowTitle', () => {
+  const PUSH = '\x1b[22;2t';
+  const POP = '\x1b[23;2t';
+  const osc = (title: string) => `\x1b]2;${title}\x07`;
+
+  const originalIsTty = Object.getOwnPropertyDescriptor(
+    process.stdout,
+    'isTTY'
+  );
+  const asTty = (isTTY: boolean) =>
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: isTTY,
+      configurable: true,
+    });
+
+  let writes: string[];
+
+  beforeEach(() => {
+    writes = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    asTty(true);
+  });
+
+  afterEach(() => {
+    // The title stack is module-level state. Popping returns it to
+    // "nothing pushed" so each test starts from the same place.
+    restoreWindowTitle();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (originalIsTty) {
+      Object.defineProperty(process.stdout, 'isTTY', originalIsTty);
+    }
+  });
+
+  it('pushes the old title once, sets ours, and pops it back', () => {
+    setWindowTitle('my-repo');
+    setWindowTitle('other-repo');
+    restoreWindowTitle();
+
+    expect(writes).toEqual([PUSH, osc('my-repo'), osc('other-repo'), POP]);
+  });
+
+  it('strips control characters that would end the OSC string early', () => {
+    setWindowTitle('my\x07-\x1brepo');
+
+    expect(writes).toContain(osc('my-repo'));
+  });
+
+  it('writes nothing when stdout is not a TTY', () => {
+    asTty(false);
+
+    setWindowTitle('my-repo');
+    restoreWindowTitle();
+
+    expect(writes).toEqual([]);
+  });
+
+  it('does not pop a title it never pushed', () => {
+    restoreWindowTitle();
+
+    expect(writes).toEqual([]);
+  });
+});

--- a/apps/cli/src/utils/window-title.spec.ts
+++ b/apps/cli/src/utils/window-title.spec.ts
@@ -93,6 +93,10 @@ describe('setWindowTitle', () => {
   afterAll(() => {
     if (originalIsTty) {
       Object.defineProperty(process.stdout, 'isTTY', originalIsTty);
+    } else {
+      // isTTY wasn't an own property to begin with — drop our stub
+      // rather than leaving a stale value behind for other suites.
+      delete (process.stdout as { isTTY?: boolean }).isTTY;
     }
   });
 
@@ -105,7 +109,8 @@ describe('setWindowTitle', () => {
   });
 
   it('strips control characters that would end the OSC string early', () => {
-    setWindowTitle('my\x07-\x1brepo');
+    // BEL (C0), ESC (C0), and ST (C1, 0x9c) all terminate an OSC string.
+    setWindowTitle('my\x07-\x1b\x9crepo');
 
     expect(writes).toContain(osc('my-repo'));
   });

--- a/apps/cli/src/utils/window-title.ts
+++ b/apps/cli/src/utils/window-title.ts
@@ -1,0 +1,64 @@
+/**
+ * Terminal window/tab title.
+ *
+ * Ink has no window-title API — the title is an OSC escape sequence
+ * written straight to stdout, outside of Ink's frame. It draws nothing,
+ * so it can't collide with Ink's diffed output.
+ */
+import { execFileSync } from 'node:child_process';
+import { basename, dirname } from 'node:path';
+
+const setTitle = (title: string) => `\x1b]2;${title}\x07`;
+
+// XTWINOPS: push the current title onto the terminal's own title stack,
+// pop it back on quit. Terminals without a title stack ignore both and
+// simply keep the title Kirby set.
+const PUSH_TITLE = '\x1b[22;2t';
+const POP_TITLE = '\x1b[23;2t';
+
+let pushed = false;
+
+/**
+ * Name of the repo Kirby is driving.
+ *
+ * Resolved from the *common* git dir, so a Kirby launched from inside
+ * one of its own worktrees still titles the tab with the parent repo
+ * rather than the session directory.
+ */
+export function repoTitle(cwd: string = process.cwd()): string {
+  try {
+    const commonDir = execFileSync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+      { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    ).trim();
+    if (commonDir) return basename(dirname(commonDir));
+  } catch {
+    // Not a git repo, or git predates --path-format (2.31).
+  }
+  return basename(cwd);
+}
+
+/** Control characters would terminate the OSC string early. */
+function sanitize(title: string): string {
+  // eslint-disable-next-line no-control-regex
+  return title.replace(/[\x00-\x1f\x7f]/g, '');
+}
+
+export function setWindowTitle(title: string): void {
+  const clean = sanitize(title);
+  if (!process.stdout.isTTY || !clean) return;
+
+  if (!pushed) {
+    process.stdout.write(PUSH_TITLE);
+    pushed = true;
+  }
+  process.stdout.write(setTitle(clean));
+}
+
+/** Hand the tab back the title it had before Kirby started. */
+export function restoreWindowTitle(): void {
+  if (!pushed) return;
+  pushed = false;
+  process.stdout.write(POP_TITLE);
+}

--- a/apps/cli/src/utils/window-title.ts
+++ b/apps/cli/src/utils/window-title.ts
@@ -39,10 +39,14 @@ export function repoTitle(cwd: string = process.cwd()): string {
   return basename(cwd);
 }
 
-/** Control characters would terminate the OSC string early. */
+/**
+ * Strip control characters that could terminate the OSC string early:
+ * C0 (0x00–0x1f), DEL (0x7f), and C1 (0x80–0x9f) — 0x9c is ST in 8-bit
+ * terminals.
+ */
 function sanitize(title: string): string {
   // eslint-disable-next-line no-control-regex
-  return title.replace(/[\x00-\x1f\x7f]/g, '');
+  return title.replace(/[\x00-\x1f\x7f-\x9f]/g, '');
 }
 
 export function setWindowTitle(title: string): void {


### PR DESCRIPTION
## What

Each Kirby tab now names the terminal window/tab after the git repo it's driving, instead of every tab showing `kirby`. A terminal full of Kirbys becomes legible at a glance.

## How it works

`apps/cli/src/utils/window-title.ts` writes an OSC 2 ("set window title") escape sequence to stdout at startup. Ink has no window-title API — the title is a terminal capability outside Ink's render tree, and the sequence emits no visible characters, so it never collides with Ink's frame diffing.

- **`repoTitle(cwd)`** resolves the name from git's *common* dir (`git rev-parse --git-common-dir`), so launching Kirby from inside one of its own `.claude/worktrees/` checkouts still titles the tab with the parent repo rather than the session directory. Outside a git repo it falls back to the directory basename.
- **Title stack.** `setWindowTitle` pushes the terminal's existing title (XTWINOPS `CSI 22;2t`) before setting ours; the `process.on('exit')` handler in `apps/cli/src/main.tsx` pops it (`CSI 23;2t`), handing the tab back the title it had before Kirby ran. Terminals without a title stack ignore both and simply keep the name Kirby set.
- **Guards.** Nothing is written when stdout isn't a TTY, and control characters that would terminate the OSC string early are stripped from the title.

## Files

- `apps/cli/src/utils/window-title.ts` — `repoTitle`, `setWindowTitle`, `restoreWindowTitle`
- `apps/cli/src/main.tsx` — sets the title after the optional `chdir`, restores it on exit
- `apps/cli/src/utils/window-title.spec.ts` — git resolution (repo root, linked worktree, non-repo fallback) and the push/set/pop escape sequences

## Manual QA

Ran Kirby in a real PTY against a scratch repo named `acme-widgets` and inspected the raw byte stream: push `CSI 22;2t`, set `\x1b]2;acme-widgets\x07`, then pop `CSI 23;2t` on quitting with `q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)